### PR TITLE
Use actual linkable URL's for the readme and add a breaking newline

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # CCS specifications
 
-Website: https://ccs-specs.icpc.io
-Github: https://github.com/icpc/ccs-specs
+Website: <https://ccs-specs.icpc.io>  
+Github: <https://github.com/icpc/ccs-specs>
 
 ```note
 


### PR DESCRIPTION
<img width="423" alt="image" src="https://user-images.githubusercontent.com/550145/96500455-34a6e000-124f-11eb-9f2a-a675545035d7.png">

The two spaces after the first URL are important to get an actual newline. If you use two newlines (instead of two spaces and a newline) you get a paragraph which doesn't look good.