### PR TITLE
Fix links and formatting

### DIFF
--- a/Contest_API.md
+++ b/Contest_API.md
@@ -75,9 +75,9 @@ the URL path
 returns
 
 ```json
-[ { "id":<id1>, <element specific data for id1>},  
-  { "id":<id2>, <element specific data for id2>},  
-     ...  
+[ { "id":<id1>, <element specific data for id1>},
+  { "id":<id2>, <element specific data for id2>},
+     ...
 ]
 ```
 
@@ -111,14 +111,14 @@ below (see [PATCH start\_time](#PATCH_start_time)). However,
 for future compatibility below are already listed other methods with
 their expected behavior, if implemented.
 
-  - `GET`  
+  - `GET`
     Read data. This method is idempotent and does not modify any data.
     It can be used to request a whole collection or a specific element.
-  - `POST`  
+  - `POST`
     Create a new element. This can only be called on a collection
     endpoint. No **id** attribute should be specified as it is up to the
     server to assign one, which is returned in the location header.
-  - `PUT`  
+  - `PUT`
     Replaces a specific element. This method is idempotent and can only
     be called on a specific element and replaces its contents with the
     data provided. The payload data must be complete, i.e. no partial
@@ -126,14 +126,14 @@ their expected behavior, if implemented.
     not need to be specified (other than in the URL) and if specified
     different from in the URL, a **409 Conflict** HTTP code should be
     returned.
-  - `PATCH`  
+  - `PATCH`
     Updates/modifies a specific element. Similar to **PUT** but allows
     partial updates by providing only that data, for example:
     `PATCH  https://example.com/api/contests/wf14/teams/10`
     with JSON contents
     `{"name":"Our cool new team name"}`
     No updates of the **id** attribute are allowed either.
-  - `DELETE`  
+  - `DELETE`
     Delete a specific element. Idempotent, but may return a 404 status
     code when repeated. Any provided data is ignored. Example:
     `DELETE  https://example.com/api/contests/wf14/teams/8`
@@ -192,31 +192,31 @@ consistent with respect to the optional parts of each type, e.g. if the
 optional .uuu is included in any absolute timestamp it must be included
 when outputting all absolute timestamps.
 
-  - Integers  
+  - Integers
     (type **`integer`** in the specification) are JSON numbers that are
     restricted to be integer. They should be represented in standard
     integer representation `(-)?[0-9]+`.
-  - Floating point numbers  
+  - Floating point numbers
     (type **`float`** in the specification) are arbitrary JSON numbers
     that are expected to take non-integer values. It is recommended to
     use a decimal representation.
-  - Fixed point numbers  
+  - Fixed point numbers
     (type **`decimal`** in the specification) are JSON numbers that are
     expected to take non-integer values. They must be in decimal
     (non-scientific) representation and have at most 3 decimals. That
     is, they must be a integer multiple of `0.001`.
-  - Absolute timestamps  
+  - Absolute timestamps
     (type **`TIME`** in the specification) are strings containing
     human-readable timestamps, given in
     [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) extended combined
     date/time format with timezone:
     `yyyy-mm-ddThh:mm:ss(.uuu)?[+-]zz(:mm)?` (or timezone `Z` for UTC).
-  - Relative times  
+  - Relative times
     (type **`RELTIME`** in the specification) are strings containing
     human-readable time durations, given in a slight modification of the
     [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) extended time
     format: `(-)?(h)*h:mm:ss(.uuu)?`
-  - Identifiers  
+  - Identifiers
     (type **`ID`** in the specification) are given as string consisting
     of characters `[a-zA-Z0-9_-]` of length at most 36 and not starting
     with a `-` (dash). IDs are unique within each endpoint.
@@ -231,7 +231,7 @@ when outputting all absolute timestamps.
     short as reasonable but not more than 10 characters. IDs not marked
     as labels may be random characters and cannot be assumed to be
     suitable for display purposes.
-  - Ordinals  
+  - Ordinals
     (type **`ORDINAL`** in the specification) are used to give an
     explicit order to a list of objects. Ordinal attributes are integers
     and must be non-negative and unique in a list of objects, and they
@@ -239,7 +239,7 @@ when outputting all absolute timestamps.
     must not assume that the ordinals start at zero nor that they are
     sequential. Instead the ordinal values should be used to sort the
     list of objects.
-  - File references  
+  - File references
     (types **`IMAGE`**, **`VIDEO`**, **`ARCHIVE`** and **`STREAM`** in
     the specification) are represented as a JSON object with elements as
     defined below.
@@ -273,10 +273,10 @@ For example
 with JSON data
 
 ```json
-{ "id":"inst105",  
-  "name":"Carnegie Mellon University",  
-  ...  
-  "logo": [{"data": "<base64 string>", "width": 160, "height": 160}]  
+{ "id":"inst105",
+  "name":"Carnegie Mellon University",
+  ...
+  "logo": [{"data": "<base64 string>", "width": 160, "height": 160}]
 }
 ```
 
@@ -311,9 +311,9 @@ are mentioned below.
 The endpoints can be categorised into 3 groups as follows:
 
   - Configuration: contests, judgement-types, languages, problems,
-    groups, organizations, teams, team-members  
+    groups, organizations, teams, team-members
     Live data: state, submissions, judgements, runs, clarifications,
-    awards  
+    awards
     Aggregate data: scoreboard, event-feed
 
 Configuration is normally set before contest start. Is not expected to,
@@ -338,16 +338,16 @@ NDJSON format.
 In the tables below, the columns are:
 
   - Name: Attribute name; object sub-attributes are indicated as
-    `object.attribute`.  
+    `object.attribute`.
     Type: Data type of the attribute; either a [JSON
     type](https://en.wikipedia.org/wiki/JSON#Data_types.2C_syntax_and_example)
-    or [a type defined above](#Recurring_details).  
+    or [a type defined above](#Recurring_details).
     Required?: Whether this is a required attribute that **must** be
-    implemented to conform to this specification.  
+    implemented to conform to this specification.
     Nullable?: Whether the attribute might be `null` (and thus
-    implicitly can also not be present in that case).  
+    implicitly can also not be present in that case).
     Source @WF: Specifies whether this attribute is implemented at the
-    ICPC World Finals and by whom.  
+    ICPC World Finals and by whom.
     Description: Description of the meaning of the attribute and any
     special considerations.
 
@@ -357,14 +357,14 @@ Furthermore, optional attributes must still be consistently implemented
 attributes that are:
 
   - Required and not nullable: The attribute must always be present with
-    a value.  
+    a value.
     Required and nullable: The attribute may be `null`, and only in that
-    case it may be left out.  
+    case it may be left out.
     Optional and not nullable: The attribute may not be implemented, but
     that implies that no element of the endpoint has the attribute set.
     If one element has this attribute present, then it must be not
     `null` and the same must be true for all same type elements within
-    the contest.  
+    the contest.
     Optional and nullable: The attribute may be `null` or not present.
     In the latter case that can either be because it was a left out
     `null` value or because it was not implemented.
@@ -436,19 +436,19 @@ Request:
 Returned data:
 
 ```json
-{  
-   "id": "wf2014",  
-   "name": "2014 ICPC World Finals",  
-   "formal_name": "38th Annual World Finals of the ACM International Collegiate Programming Contest",  
-   "start_time": "2014-06-25T10:00:00+01",  
-   "duration": "5:00:00",  
-   "scoreboard_freeze_duration": "1:00:00",  
-   "penalty_time": 20,  
-   "banner": [{  
-       "href": "https://example.com/api/contests/wf2014/banner",  
-       "width": 1920,  
-       "height": 240  
-   }]  
+{
+   "id": "wf2014",
+   "name": "2014 ICPC World Finals",
+   "formal_name": "38th Annual World Finals of the ACM International Collegiate Programming Contest",
+   "start_time": "2014-06-25T10:00:00+01",
+   "duration": "5:00:00",
+   "scoreboard_freeze_duration": "1:00:00",
+   "penalty_time": 20,
+   "banner": [{
+       "href": "https://example.com/api/contests/wf2014/banner",
+       "width": 1920,
+       "height": 240
+   }]
 }
 ```
 
@@ -459,12 +459,12 @@ Request:
 Returned data:
 
 ```json
-{  
-   "id": "dress2016",  
-   "name": "2016 ICPC World Finals Dress Rehearsal",  
-   "start_time": null,  
-   "countdown_pause_time": "0:03:38.749",  
-   "duration": "2:30:00"  
+{
+   "id": "dress2016",
+   "name": "2016 ICPC World Finals Dress Rehearsal",
+   "start_time": null,
+   "countdown_pause_time": "0:03:38.749",
+   "duration": "2:30:00"
 }
 ```
 
@@ -475,9 +475,9 @@ Request:
 Request data:
 
 ```json
-{  
-   "id": "wf2014",  
-   "start_time": "2014-06-25T10:00:00+01"  
+{
+   "id": "wf2014",
+   "start_time": "2014-06-25T10:00:00+01"
 }
 ```
 
@@ -488,9 +488,9 @@ Request:
 Request data:
 
 ```json
-{  
-   "id": "wf2016",  
-   "start_time": null  
+{
+   "id": "wf2016",
+   "start_time": null
 }
 ```
 
@@ -576,16 +576,16 @@ Request:
 Returned data:
 
 ```json
-[{  
-   "id": "CE",  
-   "name": "Compiler Error",  
-   "penalty": false,  
-   "solved": false  
-}, {  
-   "id": "AC",  
-   "name": "Accepted",  
-   "penalty": false,  
-   "solved": true  
+[{
+   "id": "CE",
+   "name": "Compiler Error",
+   "penalty": false,
+   "solved": false
+}, {
+   "id": "AC",
+   "name": "Accepted",
+   "penalty": false,
+   "solved": true
 }]
 ```
 
@@ -596,11 +596,11 @@ Request:
 Returned data:
 
 ```json
-{  
-   "id": "AC",  
-   "name": "Accepted",  
-   "penalty": false,  
-   "solved": true  
+{
+   "id": "AC",
+   "name": "Accepted",
+   "penalty": false,
+   "solved": true
 }
 ```
 
@@ -667,15 +667,15 @@ Request:
 Returned data:
 
 ```json
-[{  
-   "id": "java",  
-   "name": "Java"  
-}, {  
-   "id": "cpp",  
-   "name": "GNU C++"  
-}, {  
-   "id": "python2",  
-   "name": "Python 2"  
+[{
+   "id": "java",
+   "name": "Java"
+}, {
+   "id": "cpp",
+   "name": "GNU C++"
+}, {
+   "id": "python2",
+   "name": "Python 2"
 }]
 ```
 
@@ -718,8 +718,8 @@ Request:
 Returned data:
 
 ```json
-[{"id":"asteroids","label":"A","name":"Asteroid Rangers","ordinal":1,"color":"blue","rgb":"#00f","time_limit":2,"test_data_count":10},  
- {"id":"bottles","label":"B","name":"Curvy Little Bottles","ordinal":2,"color":"gray","rgb":"#808080","time_limit":3.5,"test_data_count":15}  
+[{"id":"asteroids","label":"A","name":"Asteroid Rangers","ordinal":1,"color":"blue","rgb":"#00f","time_limit":2,"test_data_count":10},
+ {"id":"bottles","label":"B","name":"Curvy Little Bottles","ordinal":2,"color":"gray","rgb":"#808080","time_limit":3.5,"test_data_count":15}
 ]
 ```
 
@@ -785,7 +785,7 @@ Returned data:
 
 ```json
 [
-  {"id":"42425","name":"Division 2","type":"division"}  
+  {"id":"42425","name":"Division 2","type":"division"}
 ]
 ```
 
@@ -835,11 +835,11 @@ Request:
 Returned data:
 
 ```json
-[{"id":"inst123","icpc_id":"433","name":"Shanghai Jiao Tong U.","formal_name":"Shanghai Jiao Tong University"},  
- {"id":"inst105","name":"Carnegie Mellon University","country":"USA",  
-  "logo":[{"href":"http://example.com/api/contests/wf14/organizations/inst105/logo/56px","width":56,"height":56},  
-          {"href":"http://example.com/api/contests/wf14/organizations/inst105/logo/160px","width":160,"height":160}]  
- }  
+[{"id":"inst123","icpc_id":"433","name":"Shanghai Jiao Tong U.","formal_name":"Shanghai Jiao Tong University"},
+ {"id":"inst105","name":"Carnegie Mellon University","country":"USA",
+  "logo":[{"href":"http://example.com/api/contests/wf14/organizations/inst105/logo/56px","width":56,"height":56},
+          {"href":"http://example.com/api/contests/wf14/organizations/inst105/logo/160px","width":160,"height":160}]
+ }
 ]
 ```
 
@@ -894,8 +894,8 @@ Request:
 Returned data:
 
 ```json
-[{"id":"11","icpc_id":"201433","name":"Shanghai Tigers","organization_id":"inst123","group_ids":["asia-74324325532"]},  
- {"id":"123","name":"CMU1","organization_id":"inst105","group_ids":["8","11"]}  
+[{"id":"11","icpc_id":"201433","name":"Shanghai Tigers","organization_id":"inst123","group_ids":["asia-74324325532"]},
+ {"id":"123","name":"CMU1","organization_id":"inst105","group_ids":["8","11"]}
 ]
 ```
 
@@ -936,8 +936,8 @@ Request:
 Returned data:
 
 ```json
-[{"id":"john-smith","team_id":"43","icpc_id":"32442","first_name":"John","last_name":"Smith","sex":"male","role":"contestant"},  
- {"id":"osten-umlautsen","team_id":"43","icpc_id":null,"first_name":"Östen","last_name":"Ümlautsen","sex":null,"role":"coach"}  
+[{"id":"john-smith","team_id":"43","icpc_id":"32442","first_name":"John","last_name":"Smith","sex":"male","role":"contestant"},
+ {"id":"osten-umlautsen","team_id":"43","icpc_id":null,"first_name":"Östen","last_name":"Ümlautsen","sex":null,"role":"coach"}
 ]
 ```
 
@@ -970,7 +970,7 @@ thawed either, or, it may be finalized before it is thawed. That, is the
 following sequence of inequalities must hold:
 
 ```
-started < frozen < ended < thawed    < end_of_updates,  
+started < frozen < ended < thawed    < end_of_updates,
                    ended < finalized < end_of_updates.
 ```
 
@@ -993,13 +993,13 @@ Request:
 Returned data:
 
 ```json
-{  
-  "started": "2014-06-25T10:00:00+01",  
-  "ended": null,  
-  "frozen": "2014-06-25T14:00:00+01",  
-  "thawed": null,  
-  "finalized": null,  
-  "end_of_updates": null  
+{
+  "started": "2014-06-25T10:00:00+01",
+  "ended": null,
+  "frozen": "2014-06-25T14:00:00+01",
+  "thawed": null,
+  "finalized": null,
+  "end_of_updates": null
 }
 ```
 
@@ -1061,9 +1061,9 @@ Request:
 Returned data:
 
 ```json
-[{"id":"187","team_id":"123","problem_id":"10-asteroids",  
-  "language_id":"1-java","time":"2014-06-25T11:22:05.034+01","contest_time":"1:22:05.034","entry_point":"Main",  
-  "files":[{"href":"contests/wf14/submissions/187/files","mime":"application/zip"}]}  
+[{"id":"187","team_id":"123","problem_id":"10-asteroids",
+  "language_id":"1-java","time":"2014-06-25T11:22:05.034+01","contest_time":"1:22:05.034","entry_point":"Main",
+  "files":[{"href":"contests/wf14/submissions/187/files","mime":"application/zip"}]}
 ]
 ```
 
@@ -1117,10 +1117,10 @@ Request:
 Returned data:
 
 ```json
-[{"id":"189549","submission_id":"wf2017-32163123xz3132yy","judgement_type_id":"CE","start_time":"2014-06-25T11:22:48.427+01",  
-  "start_contest_time":"1:22:48.427","end_time":"2014-06-25T11:23:32.481+01","end_contest_time":"1:23:32.481"},  
- {"id":"189550","submission_id":"wf2017-32163123xz3133ub","judgement_type_id":null,"start_time":"2014-06-25T11:24:03.921+01",  
-  "start_contest_time":"1:24:03.921","end_time":null,"end_contest_time":null}  
+[{"id":"189549","submission_id":"wf2017-32163123xz3132yy","judgement_type_id":"CE","start_time":"2014-06-25T11:22:48.427+01",
+  "start_contest_time":"1:22:48.427","end_time":"2014-06-25T11:23:32.481+01","end_contest_time":"1:23:32.481"},
+ {"id":"189550","submission_id":"wf2017-32163123xz3133ub","judgement_type_id":null,"start_time":"2014-06-25T11:24:03.921+01",
+  "start_contest_time":"1:24:03.921","end_time":null,"end_contest_time":null}
 ]
 ```
 
@@ -1165,8 +1165,8 @@ Request:
 Returned data:
 
 ```json
-[{"id":"1312","judgement_id":"189549","ordinal":28,"judgement_type_id":"TLE",  
-  "time":"2014-06-25T11:22:42.420+01","contest_time":"1:22:42.420"}  
+[{"id":"1312","judgement_id":"189549","ordinal":28,"judgement_type_id":"TLE",
+  "time":"2014-06-25T11:22:42.420+01","contest_time":"1:22:42.420"}
 ]
 ```
 
@@ -1214,8 +1214,8 @@ Request:
 Returned data:
 
 ```json
-[{"id":"wf2017-1","from_team_id":null,"to_team_id":null,"reply_to_id":null,"problem_id":null,  
-  "text":"Do not touch anything before the contest starts!","time":"2014-06-25T11:59:27.543+01","contest_time":"-0:15:32.457"}  
+[{"id":"wf2017-1","from_team_id":null,"to_team_id":null,"reply_to_id":null,"problem_id":null,
+  "text":"Do not touch anything before the contest starts!","time":"2014-06-25T11:59:27.543+01","contest_time":"-0:15:32.457"}
 ]
 ```
 
@@ -1226,10 +1226,10 @@ Request:
 Returned data:
 
 ```json
-[{"id":"1","from_team_id":"34","to_team_id":null,"reply_to_id":null,"problem_id":null,  
-  "text":"May I ask a question?","time":"2017-06-25T11:59:27.543+01","contest_time":"1:59:27.543"},  
- {"id":"2","from_team_id":null,"to_team_id":"34","reply_to_id":"1","problem_id":null,  
-  "text":"Yes you may!","time":"2017-06-25T11:59:47.543+01","contest_time":"1:59:47.543"}  
+[{"id":"1","from_team_id":"34","to_team_id":null,"reply_to_id":null,"problem_id":null,
+  "text":"May I ask a question?","time":"2017-06-25T11:59:27.543+01","contest_time":"1:59:27.543"},
+ {"id":"2","from_team_id":null,"to_team_id":"34","reply_to_id":"1","problem_id":null,
+  "text":"Yes you may!","time":"2017-06-25T11:59:47.543+01","contest_time":"1:59:47.543"}
 ]
 ```
 
@@ -1240,8 +1240,8 @@ Request:
 Returned data:
 
 ```json
-[{"id":"1","from_team_id":"34","text":"May I ask a question?","time":"2017-06-25T11:59:27.543+01","contest_time":"1:59:27.543"},  
- {"id":"2","to_team_id":"34","reply_to_id":"1","text":"Yes you may!","time":"2017-06-25T11:59:47.543+01","contest_time":"1:59:47.543"}  
+[{"id":"1","from_team_id":"34","text":"May I ask a question?","time":"2017-06-25T11:59:27.543+01","contest_time":"1:59:27.543"},
+ {"id":"2","to_team_id":"34","reply_to_id":"1","text":"Yes you may!","time":"2017-06-25T11:59:47.543+01","contest_time":"1:59:47.543"}
 ]
 ```
 
@@ -1306,9 +1306,9 @@ Request:
 Returned data:
 
 ```json
-[{"id":"gold-medal","citation":"Gold medal winner","team_ids":["54","23","1","45"]}, 
- {"id":"first-to-solve-a","citation":"First to solve problem A","team_ids":["45"]}, 
- {"id":"first-to-solve-b","citation":"First to solve problem B","team_ids":[]} 
+[{"id":"gold-medal","citation":"Gold medal winner","team_ids":["54","23","1","45"]},
+ {"id":"first-to-solve-a","citation":"First to solve problem A","team_ids":["45"]},
+ {"id":"first-to-solve-b","citation":"First to solve problem B","team_ids":[]}
 ]
 ```
 
@@ -1400,27 +1400,27 @@ Request:
 Returned data:
 
 ```json
-{  
-  "event_id": "xy1234",  
-  "time": "2014-06-25T14:13:07.832+01",  
-  "contest_time": "4:13:07.832",  
-  "state": {  
-    "started": "2014-06-25T10:00:00+01",  
-    "ended": null,  
-    "frozen": "2014-06-25T14:00:00+01",  
-    "thawed": null,  
-    "finalized": null,  
-    "end_of_updates": null  
-  },  
-  "rows": [  
-    {"rank":1,"team_id":"123","score":{"num_solved":3,"total_time":340},"problems":[  
-      {"problem_id":"1","num_judged":3,"num_pending":1,"solved":false},  
-      {"problem_id":"2","num_judged":1,"num_pending":0,"solved":true,"time":20},  
-      {"problem_id":"3","num_judged":2,"num_pending":0,"solved":true,"time":55},  
-      {"problem_id":"4","num_judged":0,"num_pending":0,"solved":false},  
-      {"problem_id":"5","num_judged":3,"num_pending":0,"solved":true,"time":205}  
-    ]}  
-  ]  
+{
+  "event_id": "xy1234",
+  "time": "2014-06-25T14:13:07.832+01",
+  "contest_time": "4:13:07.832",
+  "state": {
+    "started": "2014-06-25T10:00:00+01",
+    "ended": null,
+    "frozen": "2014-06-25T14:00:00+01",
+    "thawed": null,
+    "finalized": null,
+    "end_of_updates": null
+  },
+  "rows": [
+    {"rank":1,"team_id":"123","score":{"num_solved":3,"total_time":340},"problems":[
+      {"problem_id":"1","num_judged":3,"num_pending":1,"solved":false},
+      {"problem_id":"2","num_judged":1,"num_pending":0,"solved":true,"time":20},
+      {"problem_id":"3","num_judged":2,"num_pending":0,"solved":true,"time":55},
+      {"problem_id":"4","num_judged":0,"num_pending":0,"solved":false},
+      {"problem_id":"5","num_judged":3,"num_pending":0,"solved":true,"time":205}
+    ]}
+  ]
 }
 ```
 

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -7,6 +7,10 @@ permalink: /contest_api
 **This is the development draft for the Contest API. See also [the
 version that will be used at WF 2020](Contest_API_2020).**
 
+```note
+TODO: Remove/replace broken links.
+```
+
 ## Introduction
 
 This page describes an API for accessing information provided by a
@@ -31,7 +35,7 @@ source code
 fetching](Draft_2014_REST_interface_for_source_code_fetching),
 and the [Contest start interface](Contest_Start_Interface).
 This REST interface is specified in conjunction with a new [NDJSON event
-feed](#Event_feed), which provides all changes to this
+feed](#event-feed---draft), which provides all changes to this
 interface as CRUD-style events and is meant to supersede the old XML
 [Event Feed](Event_Feed).
 
@@ -106,8 +110,8 @@ setting the `Cache-Control` or `Expires` HTTP headers:
 ### HTTP methods
 
 The current version of this specification only requires support for the
-**GET** method, unless explicitly specified otherwise in an endpoint
-below (see [PATCH start\_time](#PATCH_start_time)). However,
+`GET` method, unless explicitly specified otherwise in an endpoint
+below (see [PATCH start\_time](#patch-starttime)). However,
 for future compatibility below are already listed other methods with
 their expected behavior, if implemented.
 
@@ -116,29 +120,29 @@ their expected behavior, if implemented.
     It can be used to request a whole collection or a specific element.
   - `POST`
     Create a new element. This can only be called on a collection
-    endpoint. No **id** attribute should be specified as it is up to the
+    endpoint. No `id` attribute should be specified as it is up to the
     server to assign one, which is returned in the location header.
   - `PUT`
     Replaces a specific element. This method is idempotent and can only
     be called on a specific element and replaces its contents with the
     data provided. The payload data must be complete, i.e. no partial
-    updates are allowed. The **id** attribute cannot be changed: it does
+    updates are allowed. The `id` attribute cannot be changed: it does
     not need to be specified (other than in the URL) and if specified
-    different from in the URL, a **409 Conflict** HTTP code should be
+    different from in the URL, a `409 Conflict` HTTP code should be
     returned.
   - `PATCH`
-    Updates/modifies a specific element. Similar to **PUT** but allows
+    Updates/modifies a specific element. Similar to `PUT` but allows
     partial updates by providing only that data, for example:
     `PATCH  https://example.com/api/contests/wf14/teams/10`
     with JSON contents
     `{"name":"Our cool new team name"}`
-    No updates of the **id** attribute are allowed either.
+    No updates of the `id` attribute are allowed either.
   - `DELETE`
     Delete a specific element. Idempotent, but may return a 404 status
     code when repeated. Any provided data is ignored. Example:
     `DELETE  https://example.com/api/contests/wf14/teams/8`
     Note that deletes must keep [referential
-    integrity](#Referential_integrity) intact.
+    integrity](#referential-integrity) intact.
 
 Standard [HTTP status
 codes](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes) are
@@ -163,7 +167,7 @@ additional roles may be supported for specific uses:
 Role-based access may completely hide some objects from the user, may
 omit certain attributes, or may embargo or omit objects based on the
 current contest time. By default, the public user has read-only access
-(no **POST**, **PUT**, **PATCH** or **DELETE** methods allowed) and does
+(no `POST`, `PUT`, `PATCH` or `DELETE` methods allowed) and does
 not have access to judgements and runs from submissions made after the
 contest freeze time.
 
@@ -173,8 +177,8 @@ Some attributes in elements are references to IDs of other elements.
 When such an attribute has a non-`null` value, then the referenced
 element must exist. That is, the full set of data exposed by the API
 must at all times be referentially intact. This implies for example that
-before creating a [team](#Teams) with an `organization_id`,
-the [organization](#Organizations) must already exist. In
+before creating a [team](#teams) with an `organization_id`,
+the [organization](#organizations) must already exist. In
 reverse, that organization can only be deleted after the team is
 deleted, or alternatively, the team's `organization_id` is set to
 `null`.
@@ -248,15 +252,15 @@ Element for file reference objects:
 
 | Name   | Type    | Nullable?          | Description                                                                                                                                                                                                                                          |
 | ------ | ------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| href   | string  | no                 | URL where the resource can be found. Relative URLs are relative to the **baseurl**. Must point to a file of intended mime-type. Resource must be accessible using the exact same (possibly none) authentication as the call that returned this data. |
+| href   | string  | no                 | URL where the resource can be found. Relative URLs are relative to the `baseurl`. Must point to a file of intended mime-type. Resource must be accessible using the exact same (possibly none) authentication as the call that returned this data. |
 | mime   | string  | no                 | Mime type of resource.                                                                                                                                                                                                                               |
 | width  | integer | no for **`IMAGE`** | Width of the image, video or stream in pixels. Should not be used for **`ARCHIVE`**.                                                                                                                                                                 |
 | height | integer | no for **`IMAGE`** | Height of the image, video or stream in pixels. Should not be used for **`ARCHIVE`**.                                                                                                                                                                |
 
-The **href** attributes may be [absolute or relative
+The `href` attributes may be [absolute or relative
 URLs](https://tools.ietf.org/html/rfc3986); relative URLs must be
-interpreted relative to the **baseurl** of the API. For example, if
-**baseurl** is <https://example.com/api>, then the following are
+interpreted relative to the `baseurl` of the API. For example, if
+`baseurl` is <https://example.com/api>, then the following are
 equivalent JSON response snippets pointing to the same location:
 
 ` "href":"https://example.com/api/contests/wf14/submissions/187/files"`
@@ -303,7 +307,7 @@ The following list of API endpoints should be supported. Note that
 `state`, `scoreboard` and `event-feed` are singular nouns and indeed
 contain only a single element.
 
-All endpoints should support **GET**; specific details on other methods
+All endpoints should support `GET`; specific details on other methods
 are mentioned below.
 
 ### Types of endpoints
@@ -328,7 +332,7 @@ Inserts and deletes are notified via the event feed. **Note**:
 judgements are the exception to immutability in a weak sense: they get
 updated once with the final verdict.
 
-Aggregate data: Only **GET** makes sense. These are not included in the
+Aggregate data: Only `GET` makes sense. These are not included in the
 event feed, also note that these should not be considered proper REST
 endpoints, and that the `event-feed` endpoint is a streaming feed in
 NDJSON format.
@@ -341,7 +345,7 @@ In the tables below, the columns are:
     `object.attribute`.
     Type: Data type of the attribute; either a [JSON
     type](https://en.wikipedia.org/wiki/JSON#Data_types.2C_syntax_and_example)
-    or [a type defined above](#Recurring_details).
+    or [a type defined above](#json-attribute-types).
     Required?: Whether this is a required attribute that **must** be
     implemented to conform to this specification.
     Nullable?: Whether the attribute might be `null` (and thus
@@ -705,9 +709,9 @@ JSON elements of problem objects:
 
 #### Access restrictions at WF
 
-The **public** role can only access these problems after the contest
+The `public` role can only access these problems after the contest
 started. That is, before contest start this endpoint returns an empty
-array for clients with the **public** role.
+array for clients with the `public` role.
 
 #### Examples
 
@@ -862,8 +866,8 @@ JSON elements of team objects:
 | icpc\_id          | string           | no        | yes       | CCS        | external identifier from ICPC CMS                                                                                                                                                                        |
 | name              | string           | yes       | no        | CCS        | name of the team                                                                                                                                                                                         |
 | display\_name     | string           | no        | yes       | CCS        | display name of the team. If not set, a client should revert to using the name instead.                                                                                                                  |
-| organization\_id  | ID               | no        | yes       | CCS        | identifier of the [ organization](#Organizations) (e.g. university or other entity) that this team is affiliated to                                                                           |
-| group\_ids        | array of ID      | no        | no        | CCS        | identifiers of the [ group(s)](#Groups) this team is part of (at ICPC WFs these are the super-regions). No meaning must be implied or inferred from the order of IDs. The array may be empty. |
+| organization\_id  | ID               | no        | yes       | CCS        | identifier of the [ organization](#organizations) (e.g. university or other entity) that this team is affiliated to                                                                           |
+| group\_ids        | array of ID      | no        | no        | CCS        | identifiers of the [ group(s)](#groups) this team is part of (at ICPC WFs these are the super-regions). No meaning must be implied or inferred from the order of IDs. The array may be empty. |
 | location          | object           | no        | no        | CDS        | JSON object as specified in the rows below                                                                                                                                                               |
 | location.x        | float            | depends   | no        | CDS        | Team's x position in meters. Required iff location is present.                                                                                                                                           |
 | location.y        | float            | depends   | no        | CDS        | Team's y position in meters. Required iff location is present.                                                                                                                                           |
@@ -881,9 +885,9 @@ JSON elements of team objects:
 
 The following access restrictions apply to a GET on this endpoint:
 
-  - **backup** requires the **admin** or **analyst** role for access,
-  - the **desktop** and **webcam** attributes are available for the
-    **public** role only when scoreboard is not frozen.
+  - `backup` requires the `admin` or `analyst` role for access,
+  - the `desktop` and `webcam` attributes are available for the
+    `public` role only when scoreboard is not frozen.
 
 #### Example
 
@@ -916,11 +920,11 @@ JSON elements of team member objects:
 | ----------- | -------------- | --------- | --------- | ---------- | -------------------------------------------------------------------------------------------- |
 | id          | ID             | yes       | no        | CDS        | identifier of the team-member                                                                |
 | icpc\_id    | string         | no        | yes       | CDS        | external identifier from ICPC CMS                                                            |
-| team\_id    | ID             | yes       | no        | CDS        | [ team](#Teams) of this team member                                               |
+| team\_id    | ID             | yes       | no        | CDS        | [ team](#teams) of this team member                                               |
 | first\_name | string         | yes       | no        | CDS        | first name of team member                                                                    |
 | last\_name  | string         | yes       | no        | CDS        | last name of team member                                                                     |
-| sex         | string         | no        | yes       | CDS        | either **male** or **female**, or possibly `null`                                            |
-| role        | string         | yes       | no        | CDS        | one of **contestant** or **coach**                                                           |
+| sex         | string         | no        | yes       | CDS        | either `male` or `female`, or possibly `null`                                            |
+| role        | string         | yes       | no        | CDS        | one of `contestant` or `coach`                                                           |
 | photo       | array of IMAGE | no        | yes       | CDS        | registration photo of the team member. Only allowed mime types are image/jpeg and image/png. |
 
 #### Access restrictions at WF
@@ -956,8 +960,8 @@ JSON elements of state objects:
 
 | Name             | Type | Required? | Nullable? | Source @WF | Description                                                                                                                                                                                                                                                |
 | ---------------- | ---- | --------- | --------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| started          | TIME | yes       | yes       | CCS        | Time when the contest actually started, or `null` if the contest has not started yet. When set, this time must be equal to the [contest](#Contests) `start_time`.                                                                               |
-| frozen           | TIME | depends   | yes       | CCS        | Time when the scoreboard was frozen, or `null` if the scoreboard has not been frozen. Required iff `scoreboard_freeze_duration` is present in the [contest](#Contests) endpoint.                                                                |
+| started          | TIME | yes       | yes       | CCS        | Time when the contest actually started, or `null` if the contest has not started yet. When set, this time must be equal to the [contest](#contests) `start_time`.                                                                               |
+| frozen           | TIME | depends   | yes       | CCS        | Time when the scoreboard was frozen, or `null` if the scoreboard has not been frozen. Required iff `scoreboard_freeze_duration` is present in the [contest](#contests) endpoint.                                                                |
 | ended            | TIME | yes       | yes       | CCS        | Time when the contest ended, or `null` if the contest has not ended. Must not be set if started is `null`.                                                                                                                                                 |
 | thawed           | TIME | depends   | yes       | CCS        | Time when the scoreboard was thawed (that is, unfrozen again), or `null` if the scoreboard has not been thawed. Required iff `scoreboard_freeze_duration` is present in the [contest](#Contests) endpoint. Must not be set if frozen is `null`. |
 | finalized        | TIME | yes       | yes       | CCS        | Time when the results were finalized, or `null` if results have not been finalized. Must not be set if ended is `null`.                                                                                                                                    |
@@ -1019,16 +1023,16 @@ JSON elements of submission objects:
 | Name          | Type             | Required? | Nullable? | Source @WF | Description                                                                                        |
 | ------------- | ---------------- | --------- | --------- | ---------- | -------------------------------------------------------------------------------------------------- |
 | id            | ID               | yes       | no        | CCS        | identifier of the submission. Usable as a label, typically a low incrementing number               |
-| language\_id  | ID               | yes       | no        | CCS        | identifier of the [ language](#Languages) submitted for                                 |
-| problem\_id   | ID               | yes       | no        | CCS        | identifier of the [ problem](#Problems) submitted for                                   |
-| team\_id      | ID               | yes       | no        | CCS        | identifier of the [ team](#Teams) that made the submission                              |
+| language\_id  | ID               | yes       | no        | CCS        | identifier of the [ language](#languages) submitted for                                 |
+| problem\_id   | ID               | yes       | no        | CCS        | identifier of the [ problem](#problems) submitted for                                   |
+| team\_id      | ID               | yes       | no        | CCS        | identifier of the [ team](#teams) that made the submission                              |
 | time          | TIME             | yes       | no        | CCS        | timestamp of when the submission was made                                                          |
 | contest\_time | RELTIME          | yes       | no        | CCS        | contest relative time when the submission was made                                                 |
 | entry\_point  | string           | yes       | yes       | CCS        | code entry point for specific languages                                                            |
 | files         | array of ARCHIVE | yes       | no        | CCS        | submission files, contained at the root of the archive. Only allowed mime type is application/zip. |
 | reaction      | array of VIDEO   | no        | yes       | CDS        | reaction video from team's webcam.                                                                 |
 
-The **entry\_point** attribute must be included for submissions in
+The `entry_point` attribute must be included for submissions in
 languages which do not have a single, unambiguous entry point to run the
 code. In general the entry point is the string that needs to be
 specified to point to the code to be executed. Specifically, for Python
@@ -1038,18 +1042,18 @@ e.g. `com.example.myclass` for a class in the package `com.example` in
 Java). For C and C++ no entry point is required and it must therefore be
 `null`.
 
-The **files** attribute provides the file(s) of a given submission as a
+The `files` attribute provides the file(s) of a given submission as a
 zip archive. These must be stored directly from the root of the zip
 file, i.e. there must not be extra directories (or files) added unless
-these are explicitly part of the submission content. For **POST**,
-**PUT** and **PATCH** methods, the **files** attribute must contain the
+these are explicitly part of the submission content. For `POST`,
+`PUT` and `PATCH` methods, the `files` attribute must contain the
 base64-encoded string of the zip archive.
 
 #### Access restrictions at WF
 
-The **entry\_point** and **files** attribute are accessible only for
-clients with **admin** or **analyst** role. The **reaction** attribute
-is available to clients with **public** role only when the contest is
+The `entry_point` and `files` attribute are accessible only for
+clients with `admin` or `analyst` role. The `reaction` attribute
+is available to clients with `public` role only when the contest is
 not frozen.
 
 #### Example
@@ -1087,8 +1091,8 @@ JSON elements of judgement objects:
 | Name                 | Type    | Required? | Nullable? | Source @WF | Description                                                     |
 | -------------------- | ------- | --------- | --------- | ---------- | --------------------------------------------------------------- |
 | id                   | ID      | yes       | no        | CCS        | identifier of the judgement                                     |
-| submission\_id       | ID      | yes       | no        | CCS        | identifier of the [ submission](#Submissions) judged |
-| judgement\_type\_id  | ID      | yes       | yes       | CCS        | the [ verdict](#Judgement_Types) of this judgement   |
+| submission\_id       | ID      | yes       | no        | CCS        | identifier of the [ submission](#submissions) judged |
+| judgement\_type\_id  | ID      | yes       | yes       | CCS        | the [ verdict](#judgement-types) of this judgement   |
 | start\_time          | TIME    | yes       | no        | CCS        | absolute time when judgement started                            |
 | start\_contest\_time | RELTIME | yes       | no        | CCS        | contest relative time when judgement started                    |
 | end\_time            | TIME    | yes       | yes       | CCS        | absolute time when judgement completed                          |
@@ -1101,7 +1105,7 @@ judgement is completed.
 
 #### Access restrictions at WF
 
-For clients with the **public** role, judgements will not be included
+For clients with the `public` role, judgements will not be included
 for submissions received while the scoreboard is frozen. This means that
 all judgements for submissions received before the scoreboard has been
 frozen will be sent immediately, and all judgements for submissions
@@ -1140,16 +1144,16 @@ JSON elements of run objects:
 | Name                | Type    | Required? | Nullable? | Source @WF | Description                                                                                                                                                                                 |
 | ------------------- | ------- | --------- | --------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | id                  | ID      | yes       | no        | CCS        | identifier of the run                                                                                                                                                                       |
-| judgement\_id       | ID      | yes       | no        | CCS        | identifier of the [ judgement](#Judgements) this is part of                                                                                                                      |
+| judgement\_id       | ID      | yes       | no        | CCS        | identifier of the [ judgement](#judgements) this is part of                                                                                                                      |
 | ordinal             | ORDINAL | yes       | no        | CCS        | ordering of runs in the judgement. Must be different for every run in a judgement. Runs for the same test case must have the same ordinal. Must be between 1 and `problem:test_data_count`. |
-| judgement\_type\_id | ID      | yes       | no        | CCS        | the [ verdict](#Judgement_Types) of this judgement (i.e. a judgement type)                                                                                                       |
+| judgement\_type\_id | ID      | yes       | no        | CCS        | the [ verdict](#judgement-types) of this judgement (i.e. a judgement type)                                                                                                       |
 | time                | TIME    | yes       | no        | CCS        | absolute time when run completed                                                                                                                                                            |
 | contest\_time       | RELTIME | yes       | no        | CCS        | contest relative time when run completed                                                                                                                                                    |
 | run\_time           | decimal | no        | no        | CCS        | run time in seconds                                                                                                                                                                         |
 
 #### Access restrictions at WF
 
-For clients with the **public** role, runs will not be included for
+For clients with the `public` role, runs will not be included for
 submissions received while the scoreboard is frozen. This means that all
 runs for submissions received before the scoreboard has been frozen will
 be sent immediately, and all runs for submissions received after the
@@ -1188,10 +1192,10 @@ JSON elements of clarification message objects:
 | Name           | Type    | Required? | Nullable? | Source @WF | Description                                                                                                                   |
 | -------------- | ------- | --------- | --------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------- |
 | id             | ID      | yes       | no        | CCS        | identifier of the clarification                                                                                               |
-| from\_team\_id | ID      | yes       | yes       | CCS        | identifier of [ team](#Teams) sending this clarification request, `null` if a clarification sent by jury           |
-| to\_team\_id   | ID      | yes       | yes       | CCS        | identifier of the [ team](#Teams) receiving this reply, `null` if a reply to all teams or a request sent by a team |
+| from\_team\_id | ID      | yes       | yes       | CCS        | identifier of [ team](#teams) sending this clarification request, `null` if a clarification sent by jury           |
+| to\_team\_id   | ID      | yes       | yes       | CCS        | identifier of the [ team](#teams) receiving this reply, `null` if a reply to all teams or a request sent by a team |
 | reply\_to\_id  | ID      | yes       | yes       | CCS        | identifier of clarification this is in response to, otherwise `null`                                                          |
-| problem\_id    | ID      | yes       | yes       | CCS        | identifier of associated [ problem](#Problems), `null` if not associated to a problem                              |
+| problem\_id    | ID      | yes       | yes       | CCS        | identifier of associated [ problem](#problems), `null` if not associated to a problem                              |
 | text           | string  | yes       | no        | CCS        | question or reply text                                                                                                        |
 | time           | TIME    | yes       | no        | CCS        | time of the question/reply                                                                                                    |
 | contest\_time  | RELTIME | yes       | no        | CCS        | contest time of the question/reply                                                                                            |
@@ -1201,7 +1205,7 @@ Note that at least one of `from_team_id` and `to_team_id` has to be
 
 #### Access restrictions at WF
 
-Clients with the **public** role can only view clarifications replies
+Clients with the `public` role can only view clarifications replies
 from the jury to all teams, that is, messages where both `from_team_id`
 and `to_team_id` are `null`.
 
@@ -1262,11 +1266,11 @@ JSON elements of award objects:
 | --------- | ----------- | --------- | --------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | id        | ID          | yes       | no        | CCS        | identifier of the award.                                                                                                                                 |
 | citation  | string      | yes       | no        | CCS        | award citation, e.g. "Gold medal winner"                                                                                                                 |
-| team\_ids | array of ID | yes       | no        | CCS        | JSON array of [ team](#Teams) ids receiving this award. No meaning must be implied or inferred from the order of IDs. The array may be empty. |
+| team\_ids | array of ID | yes       | no        | CCS        | JSON array of [ team](#teams) ids receiving this award. No meaning must be implied or inferred from the order of IDs. The array may be empty. |
 
 #### Access restrictions at WF
 
-For clients with the **public** role, awards will not include
+For clients with the `public` role, awards will not include
 information from judgements of submissions received after the scoreboard
 freeze until it has been unfrozen.
 
@@ -1316,7 +1320,7 @@ Returned data:
 
 Scoreboard of the contest.
 
-Since this is generated data, only the **GET** method is allowed here,
+Since this is generated data, only the `GET` method is allowed here,
 irrespective of role.
 
 The following endpoint is associated with the scoreboard:
@@ -1331,8 +1335,8 @@ The following options can be passed to the scoreboard endpoint.
 
 ##### Scoreboard at the time of a given event
 
-By passing an [ event](#Event_feed) ID with the
-"after\_event\_id" URL argument, the scoreboard can be requested as it
+By passing an [ event](#event-feed---draft) ID with the
+`after\_event\_id` URL argument, the scoreboard can be requested as it
 was directly after the specified event:
 
 `/scoreboard?after_event_id=xy1234`
@@ -1352,10 +1356,10 @@ JSON elements of the scoreboard object.
 
 | Name          | Type                       | Required? | Nullable? | Source @WF | Description                                                                                                                                                              |
 | ------------- | -------------------------- | --------- | --------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| event\_id     | ID                         | yes       | no        | CCS        | Identifier of the [ event](#Event_feed) after which this scoreboard was generated. This must be identical to the argument `after_event_id`, if specified.     |
+| event\_id     | ID                         | yes       | no        | CCS        | Identifier of the [ event](#event_feed) after which this scoreboard was generated. This must be identical to the argument `after_event_id`, if specified.     |
 | time          | TIME                       | yes       | no        | CCS        | Time contained in the associated event. Implementation defined if the event has no associated time.                                                                      |
 | contest\_time | RELTIME                    | yes       | no        | CCS        | Contest time contained in the associated event. Implementation defined if the event has no associated contest time.                                                      |
-| state         | object                     | yes       | no        | CCS        | Identical data as returned by the [ contest state](#Contest_state) endpoint. This is provided here for ease of use and to guarantee the data is synchronized. |
+| state         | object                     | yes       | no        | CCS        | Identical data as returned by the [ contest state](#contest-state) endpoint. This is provided here for ease of use and to guarantee the data is synchronized. |
 | rows          | JSON array of JSON objects | yes       | no        | CCS        | A list of rows of team with their associated scores.                                                                                                                     |
 
 The scoreboard `rows` array is sorted according to rank and alphabetical
@@ -1369,7 +1373,7 @@ Each JSON object in the rows array consists of:
 | Name              | Type             | Required? | Nullable? | Source @WF | Description                                                                                  |
 | ----------------- | ---------------- | --------- | --------- | ---------- | -------------------------------------------------------------------------------------------- |
 | rank              | integer          | yes       | no        | CCS        | rank of this team, 1-based and duplicate in case of ties                                     |
-| team\_id          | ID               | yes       | no        | CCS        | identifier of the [ team](#Teams)                                                 |
+| team\_id          | ID               | yes       | no        | CCS        | identifier of the [ team](#teams)                                                 |
 | score             | object           | yes       | no        | CCS        | JSON object as specified in the rows below (for possible extension to other scoring methods) |
 | score.num\_solved | integer          | yes       | no        | CCS        | number of problems solved by the team                                                        |
 | score.total\_time | integer          | yes       | no        | CCS        | total penalty time accrued by the team                                                       |
@@ -1379,7 +1383,7 @@ Each problem object within the scoreboard consists of:
 
 | Name         | Type    | Required? | Nullable? | Source @WF | Description                                                                                   |
 | ------------ | ------- | --------- | --------- | ---------- | --------------------------------------------------------------------------------------------- |
-| problem\_id  | ID      | yes       | no        | CCS        | identifier of the [ problem](#Problems)                                            |
+| problem\_id  | ID      | yes       | no        | CCS        | identifier of the [ problem](#problems)                                            |
 | num\_judged  | integer | yes       | no        | CCS        | number of judged submissions (up to and including the first correct one)                      |
 | num\_pending | integer | yes       | no        | CCS        | number of pending submissions (either queued or due to freeze)                                |
 | solved       | boolean | yes       | no        | CCS        | whether the team solved this problem                                                          |
@@ -1387,7 +1391,7 @@ Each problem object within the scoreboard consists of:
 
 #### Access restrictions at WF
 
-For clients with the **public** role, the scoreboard will not include
+For clients with the `public` role, the scoreboard will not include
 information from judgements of submissions received after the scoreboard
 has been frozen until it has been thawed.
 
@@ -1429,7 +1433,7 @@ Returned data:
 Provides the event (notification) feed for the current contest. This is
 effectively a changelog of create, update, or delete events that have
 occurred in the REST endpoints. Some endpoints (specifically the [
-Scoreboard](#Scoreboard) and the Event feed itself) are
+Scoreboard](#scoreboard) and the Event feed itself) are
 aggregated data, and so these will only ever update due to some other
 REST endpoint updating. For this reason there is no explicit event for
 these, since there will always be another event sent. This can also be
@@ -1461,9 +1465,9 @@ browser-based applications and onsite contests.
 
 #### General requirements
 
-The event responses and **data** objects contained in it must observe
+The event responses and `data` objects contained in it must observe
 the same restrictions as those of the respective endpoints they
-represent. This means that attributes inside the **data** element will
+represent. This means that attributes inside the `data` element will
 be present if and only if the client has access to those at the
 respective endpoint. The client only receives create, update and delete
 events of elements it has (partial) access to. When time-based access is
@@ -1641,7 +1645,7 @@ feed does not terminate under normal circumstances, so to ensure keep
 alive a newline must be sent if there has been no event within 120
 seconds.
 
-Since this is generated data, only the **GET** method is allowed here,
+Since this is generated data, only the `GET` method is allowed here,
 irrespective of role.
 
 The following endpoint is associated with the event feed:

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -5,18 +5,18 @@ permalink: /contest_api
 # Contest API
 
 **This is the development draft for the Contest API. See also [the
-version that will be used at WF 2020](Contest_API_2020 "wikilink").**
+version that will be used at WF 2020](Contest_API_2020).**
 
 ## Introduction
 
 This page describes an API for accessing information provided by a
-[Contest Control System](Contest_Control_System "wikilink") or [Contest
-Data Server](CDS "wikilink"). Such an API can be used by a multitude of
+[Contest Control System](Contest_Control_System) or [Contest
+Data Server](CDS). Such an API can be used by a multitude of
 clients:
 
   - an external scoreboard
   - a scoreboard resolver application
-  - contest analysis software, such as the [ICAT](ICAT "wikilink")
+  - contest analysis software, such as the [ICAT](ICAT)
     toolset
   - another "shadow" CCS, providing forwarding of submissions and all
     relevant information
@@ -26,14 +26,14 @@ clients:
 This API is meant to be useful, not only at the ICPC World Finals, but
 more generally in any ICPC-style contest setup. It is meant to
 incorporate and supersede the [JSON
-Scoreboard](JSON_Scoreboard_2016 "wikilink"), the [REST interface for
+Scoreboard](JSON_Scoreboard_2016), the [REST interface for
 source code
-fetching](Draft_2014_REST_interface_for_source_code_fetching "wikilink"),
-and the [Contest start interface](Contest_Start_Interface "wikilink").
+fetching](Draft_2014_REST_interface_for_source_code_fetching),
+and the [Contest start interface](Contest_Start_Interface).
 This REST interface is specified in conjunction with a new [NDJSON event
-feed](#Event_feed "wikilink"), which provides all changes to this
+feed](#Event_feed), which provides all changes to this
 interface as CRUD-style events and is meant to supersede the old XML
-[Event Feed](Event_Feed "wikilink").
+[Event Feed](Event_Feed).
 
 ## General design principles
 
@@ -107,7 +107,7 @@ setting the `Cache-Control` or `Expires` HTTP headers:
 
 The current version of this specification only requires support for the
 **GET** method, unless explicitly specified otherwise in an endpoint
-below (see [PATCH start\_time](#PATCH_start_time "wikilink")). However,
+below (see [PATCH start\_time](#PATCH_start_time)). However,
 for future compatibility below are already listed other methods with
 their expected behavior, if implemented.
 
@@ -138,7 +138,7 @@ their expected behavior, if implemented.
     code when repeated. Any provided data is ignored. Example:
     `DELETE  https://example.com/api/contests/wf14/teams/8`
     Note that deletes must keep [referential
-    integrity](#Referential_integrity "wikilink") intact.
+    integrity](#Referential_integrity) intact.
 
 Standard [HTTP status
 codes](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes) are
@@ -173,8 +173,8 @@ Some attributes in elements are references to IDs of other elements.
 When such an attribute has a non-`null` value, then the referenced
 element must exist. That is, the full set of data exposed by the API
 must at all times be referentially intact. This implies for example that
-before creating a [team](#Teams "wikilink") with an `organization_id`,
-the [organization](#Organizations "wikilink") must already exist. In
+before creating a [team](#Teams) with an `organization_id`,
+the [organization](#Organizations) must already exist. In
 reverse, that organization can only be deleted after the team is
 deleted, or alternatively, the team's `organization_id` is set to
 `null`.
@@ -341,7 +341,7 @@ In the tables below, the columns are:
     `object.attribute`.  
     Type: Data type of the attribute; either a [JSON
     type](https://en.wikipedia.org/wiki/JSON#Data_types.2C_syntax_and_example)
-    or [a type defined above](#Recurring_details "wikilink").  
+    or [a type defined above](#Recurring_details).  
     Required?: Whether this is a required attribute that **must** be
     implemented to conform to this specification.  
     Nullable?: Whether the attribute might be `null` (and thus
@@ -412,7 +412,7 @@ No access restrictions apply to a GET on this endpoint.
 #### PATCH start\_time
 
 To replace the [Contest Start
-Interface](Contest_Start_Interface "wikilink"), at the ICPC World
+Interface](Contest_Start_Interface), at the ICPC World
 Finals, an API provided by a CCS or CDS implementing this specification
 must have a role that has the ability to clear or set the contest start
 time via a PATCH method.
@@ -862,8 +862,8 @@ JSON elements of team objects:
 | icpc\_id          | string           | no        | yes       | CCS        | external identifier from ICPC CMS                                                                                                                                                                        |
 | name              | string           | yes       | no        | CCS        | name of the team                                                                                                                                                                                         |
 | display\_name     | string           | no        | yes       | CCS        | display name of the team. If not set, a client should revert to using the name instead.                                                                                                                  |
-| organization\_id  | ID               | no        | yes       | CCS        | identifier of the [ organization](#Organizations "wikilink") (e.g. university or other entity) that this team is affiliated to                                                                           |
-| group\_ids        | array of ID      | no        | no        | CCS        | identifiers of the [ group(s)](#Groups "wikilink") this team is part of (at ICPC WFs these are the super-regions). No meaning must be implied or inferred from the order of IDs. The array may be empty. |
+| organization\_id  | ID               | no        | yes       | CCS        | identifier of the [ organization](#Organizations) (e.g. university or other entity) that this team is affiliated to                                                                           |
+| group\_ids        | array of ID      | no        | no        | CCS        | identifiers of the [ group(s)](#Groups) this team is part of (at ICPC WFs these are the super-regions). No meaning must be implied or inferred from the order of IDs. The array may be empty. |
 | location          | object           | no        | no        | CDS        | JSON object as specified in the rows below                                                                                                                                                               |
 | location.x        | float            | depends   | no        | CDS        | Team's x position in meters. Required iff location is present.                                                                                                                                           |
 | location.y        | float            | depends   | no        | CDS        | Team's y position in meters. Required iff location is present.                                                                                                                                           |
@@ -916,7 +916,7 @@ JSON elements of team member objects:
 | ----------- | -------------- | --------- | --------- | ---------- | -------------------------------------------------------------------------------------------- |
 | id          | ID             | yes       | no        | CDS        | identifier of the team-member                                                                |
 | icpc\_id    | string         | no        | yes       | CDS        | external identifier from ICPC CMS                                                            |
-| team\_id    | ID             | yes       | no        | CDS        | [ team](#Teams "wikilink") of this team member                                               |
+| team\_id    | ID             | yes       | no        | CDS        | [ team](#Teams) of this team member                                               |
 | first\_name | string         | yes       | no        | CDS        | first name of team member                                                                    |
 | last\_name  | string         | yes       | no        | CDS        | last name of team member                                                                     |
 | sex         | string         | no        | yes       | CDS        | either **male** or **female**, or possibly `null`                                            |
@@ -956,10 +956,10 @@ JSON elements of state objects:
 
 | Name             | Type | Required? | Nullable? | Source @WF | Description                                                                                                                                                                                                                                                |
 | ---------------- | ---- | --------- | --------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| started          | TIME | yes       | yes       | CCS        | Time when the contest actually started, or `null` if the contest has not started yet. When set, this time must be equal to the [contest](#Contests "wikilink") `start_time`.                                                                               |
-| frozen           | TIME | depends   | yes       | CCS        | Time when the scoreboard was frozen, or `null` if the scoreboard has not been frozen. Required iff `scoreboard_freeze_duration` is present in the [contest](#Contests "wikilink") endpoint.                                                                |
+| started          | TIME | yes       | yes       | CCS        | Time when the contest actually started, or `null` if the contest has not started yet. When set, this time must be equal to the [contest](#Contests) `start_time`.                                                                               |
+| frozen           | TIME | depends   | yes       | CCS        | Time when the scoreboard was frozen, or `null` if the scoreboard has not been frozen. Required iff `scoreboard_freeze_duration` is present in the [contest](#Contests) endpoint.                                                                |
 | ended            | TIME | yes       | yes       | CCS        | Time when the contest ended, or `null` if the contest has not ended. Must not be set if started is `null`.                                                                                                                                                 |
-| thawed           | TIME | depends   | yes       | CCS        | Time when the scoreboard was thawed (that is, unfrozen again), or `null` if the scoreboard has not been thawed. Required iff `scoreboard_freeze_duration` is present in the [contest](#Contests "wikilink") endpoint. Must not be set if frozen is `null`. |
+| thawed           | TIME | depends   | yes       | CCS        | Time when the scoreboard was thawed (that is, unfrozen again), or `null` if the scoreboard has not been thawed. Required iff `scoreboard_freeze_duration` is present in the [contest](#Contests) endpoint. Must not be set if frozen is `null`. |
 | finalized        | TIME | yes       | yes       | CCS        | Time when the results were finalized, or `null` if results have not been finalized. Must not be set if ended is `null`.                                                                                                                                    |
 | end\_of\_updates | TIME | yes       | yes       | CCS        | Time after last update to the contest occurred, or `null` if more updates are still to come. Setting this to non-`null` must be the very last change in the contest.                                                                                       |
 
@@ -1019,9 +1019,9 @@ JSON elements of submission objects:
 | Name          | Type             | Required? | Nullable? | Source @WF | Description                                                                                        |
 | ------------- | ---------------- | --------- | --------- | ---------- | -------------------------------------------------------------------------------------------------- |
 | id            | ID               | yes       | no        | CCS        | identifier of the submission. Usable as a label, typically a low incrementing number               |
-| language\_id  | ID               | yes       | no        | CCS        | identifier of the [ language](#Languages "wikilink") submitted for                                 |
-| problem\_id   | ID               | yes       | no        | CCS        | identifier of the [ problem](#Problems "wikilink") submitted for                                   |
-| team\_id      | ID               | yes       | no        | CCS        | identifier of the [ team](#Teams "wikilink") that made the submission                              |
+| language\_id  | ID               | yes       | no        | CCS        | identifier of the [ language](#Languages) submitted for                                 |
+| problem\_id   | ID               | yes       | no        | CCS        | identifier of the [ problem](#Problems) submitted for                                   |
+| team\_id      | ID               | yes       | no        | CCS        | identifier of the [ team](#Teams) that made the submission                              |
 | time          | TIME             | yes       | no        | CCS        | timestamp of when the submission was made                                                          |
 | contest\_time | RELTIME          | yes       | no        | CCS        | contest relative time when the submission was made                                                 |
 | entry\_point  | string           | yes       | yes       | CCS        | code entry point for specific languages                                                            |
@@ -1087,8 +1087,8 @@ JSON elements of judgement objects:
 | Name                 | Type    | Required? | Nullable? | Source @WF | Description                                                     |
 | -------------------- | ------- | --------- | --------- | ---------- | --------------------------------------------------------------- |
 | id                   | ID      | yes       | no        | CCS        | identifier of the judgement                                     |
-| submission\_id       | ID      | yes       | no        | CCS        | identifier of the [ submission](#Submissions "wikilink") judged |
-| judgement\_type\_id  | ID      | yes       | yes       | CCS        | the [ verdict](#Judgement_Types "wikilink") of this judgement   |
+| submission\_id       | ID      | yes       | no        | CCS        | identifier of the [ submission](#Submissions) judged |
+| judgement\_type\_id  | ID      | yes       | yes       | CCS        | the [ verdict](#Judgement_Types) of this judgement   |
 | start\_time          | TIME    | yes       | no        | CCS        | absolute time when judgement started                            |
 | start\_contest\_time | RELTIME | yes       | no        | CCS        | contest relative time when judgement started                    |
 | end\_time            | TIME    | yes       | yes       | CCS        | absolute time when judgement completed                          |
@@ -1140,9 +1140,9 @@ JSON elements of run objects:
 | Name                | Type    | Required? | Nullable? | Source @WF | Description                                                                                                                                                                                 |
 | ------------------- | ------- | --------- | --------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | id                  | ID      | yes       | no        | CCS        | identifier of the run                                                                                                                                                                       |
-| judgement\_id       | ID      | yes       | no        | CCS        | identifier of the [ judgement](#Judgements "wikilink") this is part of                                                                                                                      |
+| judgement\_id       | ID      | yes       | no        | CCS        | identifier of the [ judgement](#Judgements) this is part of                                                                                                                      |
 | ordinal             | ORDINAL | yes       | no        | CCS        | ordering of runs in the judgement. Must be different for every run in a judgement. Runs for the same test case must have the same ordinal. Must be between 1 and `problem:test_data_count`. |
-| judgement\_type\_id | ID      | yes       | no        | CCS        | the [ verdict](#Judgement_Types "wikilink") of this judgement (i.e. a judgement type)                                                                                                       |
+| judgement\_type\_id | ID      | yes       | no        | CCS        | the [ verdict](#Judgement_Types) of this judgement (i.e. a judgement type)                                                                                                       |
 | time                | TIME    | yes       | no        | CCS        | absolute time when run completed                                                                                                                                                            |
 | contest\_time       | RELTIME | yes       | no        | CCS        | contest relative time when run completed                                                                                                                                                    |
 | run\_time           | decimal | no        | no        | CCS        | run time in seconds                                                                                                                                                                         |
@@ -1188,10 +1188,10 @@ JSON elements of clarification message objects:
 | Name           | Type    | Required? | Nullable? | Source @WF | Description                                                                                                                   |
 | -------------- | ------- | --------- | --------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------- |
 | id             | ID      | yes       | no        | CCS        | identifier of the clarification                                                                                               |
-| from\_team\_id | ID      | yes       | yes       | CCS        | identifier of [ team](#Teams "wikilink") sending this clarification request, `null` if a clarification sent by jury           |
-| to\_team\_id   | ID      | yes       | yes       | CCS        | identifier of the [ team](#Teams "wikilink") receiving this reply, `null` if a reply to all teams or a request sent by a team |
+| from\_team\_id | ID      | yes       | yes       | CCS        | identifier of [ team](#Teams) sending this clarification request, `null` if a clarification sent by jury           |
+| to\_team\_id   | ID      | yes       | yes       | CCS        | identifier of the [ team](#Teams) receiving this reply, `null` if a reply to all teams or a request sent by a team |
 | reply\_to\_id  | ID      | yes       | yes       | CCS        | identifier of clarification this is in response to, otherwise `null`                                                          |
-| problem\_id    | ID      | yes       | yes       | CCS        | identifier of associated [ problem](#Problems "wikilink"), `null` if not associated to a problem                              |
+| problem\_id    | ID      | yes       | yes       | CCS        | identifier of associated [ problem](#Problems), `null` if not associated to a problem                              |
 | text           | string  | yes       | no        | CCS        | question or reply text                                                                                                        |
 | time           | TIME    | yes       | no        | CCS        | time of the question/reply                                                                                                    |
 | contest\_time  | RELTIME | yes       | no        | CCS        | contest time of the question/reply                                                                                            |
@@ -1262,7 +1262,7 @@ JSON elements of award objects:
 | --------- | ----------- | --------- | --------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | id        | ID          | yes       | no        | CCS        | identifier of the award.                                                                                                                                 |
 | citation  | string      | yes       | no        | CCS        | award citation, e.g. "Gold medal winner"                                                                                                                 |
-| team\_ids | array of ID | yes       | no        | CCS        | JSON array of [ team](#Teams "wikilink") ids receiving this award. No meaning must be implied or inferred from the order of IDs. The array may be empty. |
+| team\_ids | array of ID | yes       | no        | CCS        | JSON array of [ team](#Teams) ids receiving this award. No meaning must be implied or inferred from the order of IDs. The array may be empty. |
 
 #### Access restrictions at WF
 
@@ -1331,7 +1331,7 @@ The following options can be passed to the scoreboard endpoint.
 
 ##### Scoreboard at the time of a given event
 
-By passing an [ event](#Event_feed "wikilink") ID with the
+By passing an [ event](#Event_feed) ID with the
 "after\_event\_id" URL argument, the scoreboard can be requested as it
 was directly after the specified event:
 
@@ -1352,10 +1352,10 @@ JSON elements of the scoreboard object.
 
 | Name          | Type                       | Required? | Nullable? | Source @WF | Description                                                                                                                                                              |
 | ------------- | -------------------------- | --------- | --------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| event\_id     | ID                         | yes       | no        | CCS        | Identifier of the [ event](#Event_feed "wikilink") after which this scoreboard was generated. This must be identical to the argument `after_event_id`, if specified.     |
+| event\_id     | ID                         | yes       | no        | CCS        | Identifier of the [ event](#Event_feed) after which this scoreboard was generated. This must be identical to the argument `after_event_id`, if specified.     |
 | time          | TIME                       | yes       | no        | CCS        | Time contained in the associated event. Implementation defined if the event has no associated time.                                                                      |
 | contest\_time | RELTIME                    | yes       | no        | CCS        | Contest time contained in the associated event. Implementation defined if the event has no associated contest time.                                                      |
-| state         | object                     | yes       | no        | CCS        | Identical data as returned by the [ contest state](#Contest_state "wikilink") endpoint. This is provided here for ease of use and to guarantee the data is synchronized. |
+| state         | object                     | yes       | no        | CCS        | Identical data as returned by the [ contest state](#Contest_state) endpoint. This is provided here for ease of use and to guarantee the data is synchronized. |
 | rows          | JSON array of JSON objects | yes       | no        | CCS        | A list of rows of team with their associated scores.                                                                                                                     |
 
 The scoreboard `rows` array is sorted according to rank and alphabetical
@@ -1369,7 +1369,7 @@ Each JSON object in the rows array consists of:
 | Name              | Type             | Required? | Nullable? | Source @WF | Description                                                                                  |
 | ----------------- | ---------------- | --------- | --------- | ---------- | -------------------------------------------------------------------------------------------- |
 | rank              | integer          | yes       | no        | CCS        | rank of this team, 1-based and duplicate in case of ties                                     |
-| team\_id          | ID               | yes       | no        | CCS        | identifier of the [ team](#Teams "wikilink")                                                 |
+| team\_id          | ID               | yes       | no        | CCS        | identifier of the [ team](#Teams)                                                 |
 | score             | object           | yes       | no        | CCS        | JSON object as specified in the rows below (for possible extension to other scoring methods) |
 | score.num\_solved | integer          | yes       | no        | CCS        | number of problems solved by the team                                                        |
 | score.total\_time | integer          | yes       | no        | CCS        | total penalty time accrued by the team                                                       |
@@ -1379,7 +1379,7 @@ Each problem object within the scoreboard consists of:
 
 | Name         | Type    | Required? | Nullable? | Source @WF | Description                                                                                   |
 | ------------ | ------- | --------- | --------- | ---------- | --------------------------------------------------------------------------------------------- |
-| problem\_id  | ID      | yes       | no        | CCS        | identifier of the [ problem](#Problems "wikilink")                                            |
+| problem\_id  | ID      | yes       | no        | CCS        | identifier of the [ problem](#Problems)                                            |
 | num\_judged  | integer | yes       | no        | CCS        | number of judged submissions (up to and including the first correct one)                      |
 | num\_pending | integer | yes       | no        | CCS        | number of pending submissions (either queued or due to freeze)                                |
 | solved       | boolean | yes       | no        | CCS        | whether the team solved this problem                                                          |
@@ -1429,7 +1429,7 @@ Returned data:
 Provides the event (notification) feed for the current contest. This is
 effectively a changelog of create, update, or delete events that have
 occurred in the REST endpoints. Some endpoints (specifically the [
-Scoreboard](#Scoreboard "wikilink") and the Event feed itself) are
+Scoreboard](#Scoreboard) and the Event feed itself) are
 aggregated data, and so these will only ever update due to some other
 REST endpoint updating. For this reason there is no explicit event for
 these, since there will always be another event sent. This can also be

--- a/Contest_Archive_Format.md
+++ b/Contest_Archive_Format.md
@@ -59,11 +59,11 @@ not listed then **archive** must be specified.
 #### Example
 
 ```yaml
-# Contest Archive  
----  
-created-by: Kattis  
-archive:    contest-api  
-problems:   kattis  
+# Contest Archive
+---
+created-by: Kattis
+archive:    contest-api
+problems:   kattis
 events:     missing
 ```
 
@@ -147,7 +147,7 @@ stored in a subfolder per object, using the object ID as the folder name
 and the element name of the file reference as the base name of the file.
 
 ```
-<endpoint>.json  
+<endpoint>.json
 <endpoint>/<id>/<referenced files>
 ```
 
@@ -175,15 +175,15 @@ appropriate specifier.
 #### Examples of Multiple File References
 
 ```
-<endpoint>/<id>/banner.800x100.png # Must be a 800 x 100 px PNG  
+<endpoint>/<id>/banner.800x100.png # Must be a 800 x 100 px PNG
 <endpoint>/<id>/banner.80x10.png   # Must be a 80 x 10 px PNG
 ```
 
 or:
 
 ```
-<endpoint>/<id>/logo.png           # Is probably the source image for the other logo versions. Must be larger than the others.  
-<endpoint>/<id>/logo.56x56.png     # Must be a 56 x 56 px PNG  
+<endpoint>/<id>/logo.png           # Is probably the source image for the other logo versions. Must be larger than the others.
+<endpoint>/<id>/logo.56x56.png     # Must be a 56 x 56 px PNG
 <endpoint>/<id>/logo.160x160.png   # Must be a 160 x 160 px PNG
 ```
 
@@ -206,12 +206,12 @@ A directory, **config**, containing:
 #### Example file listing
 
 ```
-config/contest.json  
-config/judgement-types.json  
-config/languages.json  
-config/system.yaml  
-config/banner.800x100.png  
-config/logo.png  
+config/contest.json
+config/judgement-types.json
+config/languages.json
+config/system.yaml
+config/banner.800x100.png
+config/logo.png
 config/logo.512x512.png
 ```
 
@@ -243,16 +243,16 @@ A directory, **registration**, containing:
 #### Example file listing
 
 ```
-registration/groups.json  
-registration/organizations.json  
-registration/organizations/<id>/logo.56x56.png  
-registration/organizations/<id>/logo.160x160.png  
-registration/organizations/<id>/logo.512x512.png  
-registration/teams.json  
-registration/teams/<id>/photo.png  
-registration/teams/<id>/photo.jpg  
-registration/teams/<id>/backup.zip  
-registration/team-members.json  
+registration/groups.json
+registration/organizations.json
+registration/organizations/<id>/logo.56x56.png
+registration/organizations/<id>/logo.160x160.png
+registration/organizations/<id>/logo.512x512.png
+registration/teams.json
+registration/teams/<id>/photo.png
+registration/teams/<id>/photo.jpg
+registration/teams/<id>/backup.zip
+registration/team-members.json
 registration/team-members/<id>/photo.jpg
 ```
 
@@ -273,11 +273,11 @@ A directory, **activity**, containing:
 #### Example file listing
 
 ```
-activity/submissions.json  
-activity/submissions/<id>/files.zip  
-activity/submissions/<id>/reaction.mp4  
-activity/judgements.json  
-activity/runs.json  
+activity/submissions.json
+activity/submissions/<id>/files.zip
+activity/submissions/<id>/reaction.mp4
+activity/judgements.json
+activity/runs.json
 activity/clarifications.json
 ```
 
@@ -291,7 +291,7 @@ A directory, **results**, containing:
 #### Example file listing
 
 ```
-results/awards.json  
+results/awards.json
 results/scoreboard.json
 ```
 
@@ -347,8 +347,8 @@ into the master archive are:
 #### Example file listing
 
 ```
-activity/judgements.shadow.json  
-activity/runs.shadow.json  
+activity/judgements.shadow.json
+activity/runs.shadow.json
 events/event-feed.shadow.json
 ```
 

--- a/Contest_Archive_Format.md
+++ b/Contest_Archive_Format.md
@@ -5,7 +5,7 @@ permalink: /contest_archive_format
 # Contest archive format
 
 This page describes a draft archive format for a contest. It is
-developed in parallel with the [Contest API](Contest_API "wikilink"). It
+developed in parallel with the [Contest API](Contest_API). It
 might very well end up being very similar to the CDP which has been
 suggested to use for this, but which has a slightly different purpose...
 
@@ -22,7 +22,7 @@ disk, including:
 
 This standard lays out the relative location and format of each type of
 contest-related information when reading or writing to disk. The top
-level structure is inspired by the [Contest API](Contest_API "wikilink")
+level structure is inspired by the [Contest API](Contest_API)
 structure, and a dump of the output from that API is one way to store
 the data. That said, the archive format allows for any format whose
 documentation has been registered with the ICPC. The sections below
@@ -134,7 +134,7 @@ The following formats may be used:
 
 **NB\!**: This section should not be in this document, and is only
 included here while WIP. It should either be its own document, or be
-added to the [Contest API](Contest_API "wikilink") document. Every
+added to the [Contest API](Contest_API) document. Every
 subsection defines the on disk format **contest-api** for a type of
 data.
 
@@ -197,7 +197,7 @@ A directory, **config**, containing:
   - a JSON file (`languages.json`) for the `/contests\<id>/languages`
     endpoint
   - `system.yaml` defined in the [
-    CCSR](Contest_Control_System_Requirements#system.yaml "wikilink").
+    CCSR](Contest_Control_System_Requirements#system.yaml).
   - the contest banner(s), from the banner element of `/contests/<id>`, if
     available.
   - the contest logo(s), from the logo element of `/contests/<id>`, if

--- a/Contest_Archive_Format.md
+++ b/Contest_Archive_Format.md
@@ -59,12 +59,12 @@ not listed then **archive** must be specified.
 #### Example
 
 ```yaml
-# Contest Archive  
+# Contest Archive  
 ---  
-created-by: Kattis  
-archive:    contest-api  
-problems:   kattis  
-events:     missing
+created-by: Kattis  
+archive:    contest-api  
+problems:   kattis  
+events:     missing
 ```
 
 ### Config
@@ -175,16 +175,16 @@ appropriate specifier.
 #### Examples of Multiple File References
 
 ```
-<endpoint>/<id>/banner.800x100.png # Must be a 800 x 100 px PNG  
-<endpoint>/<id>/banner.80x10.png   # Must be a 80 x 10 px PNG
+<endpoint>/<id>/banner.800x100.png # Must be a 800 x 100 px PNG  
+<endpoint>/<id>/banner.80x10.png   # Must be a 80 x 10 px PNG
 ```
 
 or:
 
 ```
-<endpoint>/<id>/logo.png           # Is probably the source image for the other logo versions. Must be larger than the others.  
-<endpoint>/<id>/logo.56x56.png     # Must be a 56 x 56 px PNG  
-<endpoint>/<id>/logo.160x160.png   # Must be a 160 x 160 px PNG
+<endpoint>/<id>/logo.png           # Is probably the source image for the other logo versions. Must be larger than the others.  
+<endpoint>/<id>/logo.56x56.png     # Must be a 56 x 56 px PNG  
+<endpoint>/<id>/logo.160x160.png   # Must be a 160 x 160 px PNG
 ```
 
 ### Config

--- a/Contest_Archive_Format.md
+++ b/Contest_Archive_Format.md
@@ -5,7 +5,7 @@ permalink: /contest_archive_format
 # Contest archive format
 
 This page describes a draft archive format for a contest. It is
-developed in parallel with the [Contest API](Contest_API). It
+developed in parallel with the [Contest API](contest_api). It
 might very well end up being very similar to the CDP which has been
 suggested to use for this, but which has a slightly different purpose...
 
@@ -22,7 +22,7 @@ disk, including:
 
 This standard lays out the relative location and format of each type of
 contest-related information when reading or writing to disk. The top
-level structure is inspired by the [Contest API](Contest_API)
+level structure is inspired by the [Contest API](contest_api)
 structure, and a dump of the output from that API is one way to store
 the data. That said, the archive format allows for any format whose
 documentation has been registered with the ICPC. The sections below
@@ -31,30 +31,30 @@ lists all currently known (and thus accepted) formats.
 ## Structure
 
 The Contest Archive consists of a single directory (possibly ZIP
-compressed) with a metadata file (**archive.yaml**) and at most a single
-entry for each of the types of data (**config**, **problems**,
-**registration**, **activity**, **results**, **events**). An entry is
+compressed) with a metadata file (`archive.yaml`) and at most a single
+entry for each of the types of data (`config`, `problems`,
+`registration`, `activity`, `results`, `events`). An entry is
 either a directory with the same name as the type of data, or a file
 with same base name as the type of data and any file extension.
 
 ### Metadata
 
-Archive metadata is stored in a YAML file called **archive.yaml** with
+Archive metadata is stored in a YAML file called `archive.yaml` with
 the following keys:
 
 | Key          | Description                                                    |
 | ------------ | -------------------------------------------------------------- |
 | created-by   | Name of system creating this archive                           |
 | archive      | ID of format used for content types not listed in archive.yaml |
-| config       | ID of format used for **config**                               |
-| problems     | ID of format used for **problems**                             |
-| registration | ID of format used for **registration**                         |
-| activity     | ID of format used for **activity**                             |
-| results      | ID of format used for **results**                              |
-| events       | ID of format used for **events**                               |
+| config       | ID of format used for `config`                               |
+| problems     | ID of format used for `problems`                             |
+| registration | ID of format used for `registration`                         |
+| activity     | ID of format used for `activity`                             |
+| results      | ID of format used for `results`                              |
+| events       | ID of format used for `events`                               |
 
-Only **created-by** is always required, but if any of content type is
-not listed then **archive** must be specified.
+Only `created-by` is always required, but if any of content type is
+not listed then `archive` must be specified.
 
 #### Example
 
@@ -134,8 +134,8 @@ The following formats may be used:
 
 **NB\!**: This section should not be in this document, and is only
 included here while WIP. It should either be its own document, or be
-added to the [Contest API](Contest_API) document. Every
-subsection defines the on disk format **contest-api** for a type of
+added to the [Contest API](contest_api) document. Every
+subsection defines the on disk format `contest-api` for a type of
 data.
 
 ### Design principles
@@ -189,7 +189,7 @@ or:
 
 ### Config
 
-A directory, **config**, containing:
+A directory, `config`, containing:
 
   - a JSON file (`contest.json`) for the `/contests/<id>` endpoint
   - a JSON file (`judgement-types.json`) for the
@@ -197,7 +197,7 @@ A directory, **config**, containing:
   - a JSON file (`languages.json`) for the `/contests\<id>/languages`
     endpoint
   - `system.yaml` defined in the [
-    CCSR](Contest_Control_System_Requirements#system.yaml).
+    CCSR](ccs_system_requirements#systemyaml).
   - the contest banner(s), from the banner element of `/contests/<id>`, if
     available.
   - the contest logo(s), from the logo element of `/contests/<id>`, if
@@ -217,7 +217,7 @@ config/logo.512x512.png
 
 ### Registration
 
-A directory, **registration**, containing:
+A directory, `registration`, containing:
 
   - a JSON file (`groups.json`) for the `/groups` endpoint, if available
   - a JSON file (`organizations.json`) for the `/organizatons` endpoint, if
@@ -258,7 +258,7 @@ registration/team-members/<id>/photo.jpg
 
 ### Activity
 
-A directory, **activity**, containing:
+A directory, `activity`, containing:
 
   - a JSON file (`submissions.json`) for the `/submissions` endpoint
   - a directory for submissions containing:
@@ -283,7 +283,7 @@ activity/clarifications.json
 
 ### Results
 
-A directory, **results**, containing:
+A directory, `results`, containing:
 
   - A JSON file (`awards.json`) for the `/awards` endpoint, if available
   - A JSON file (`scoreboard.json`) for the `/scoreboard` endpoint
@@ -297,7 +297,7 @@ results/scoreboard.json
 
 ### Events
 
-A directory, **events**, containing:
+A directory, `events`, containing:
 
   - a JSON file (`event-feed.json`) for the `/event-feed` endpoint on the
     primary system

--- a/Contest_Control_System_Requirements.md
+++ b/Contest_Control_System_Requirements.md
@@ -42,7 +42,7 @@ A contest control system may be submitted to the Director of Operations
 for the ICPC World Finals for consideration as a candidate to run the
 World Finals. The items which must be submitted in order to be
 considered are described under [ Certification
-Process](#Certification_Process) in this document. Any
+Process](#certification-process) in this document. Any
 submitted CCS which meets all of the requirements defined in this
 document will be certified as being accepted as a candidate to run the
 World Finals. Meeting or failing to meet each requirement will be
@@ -124,22 +124,22 @@ At least the following different types of accounts must be supported:
 
   - Team: used by teams competing in the contest. The functions
     available to team clients are as defined in the section on the [team
-    interface](#Team_Interface).
+    interface](#team-interface).
 
   - Judge: used by judges in the contest. The functions available to
     judge clients are as defined in the section on the [judge
-    interface](#Judge_Interface).
+    interface](#judge-interface).
 
   - Admin: used by contest administrators. The functions available to
     admin clients are as defined in the section on the [admin
-    interface](#Admin_Interface).
+    interface](#admin-interface).
 
 ### Secure Authentication
 
 The CCS must support a secure authentication mechanism, allowing each
-registered user (being either a [team](#Team_Interface), an
-[admin](#Admin_Interface), or a
-[judge](#Judge_Interface)) to gain access to the contest, and
+registered user (being either a [team](#team-interface), an
+[admin](#admin-interface), or a
+[judge](#judge-interface)) to gain access to the contest, and
 must ensure that:
 
 1.  Only users who supply correct authentication credentials may invoke
@@ -311,7 +311,7 @@ the compiler or interpreter's documentation.
 
 Problems (including judge data, validators, execution time limit, etc)
 are specified and configured using the [Problem
-format](Problem_format). The CCS must support this format
+package format](https://icpc.io/problem-package-format/). The CCS must support this format
 with the following exceptions:
 
   - The CCS does not have to support the use of the following keys in
@@ -321,6 +321,10 @@ with the following exceptions:
     for the key validation in problem.yaml.
   - The CCS does not have to support sections 5 "Included Code", 9
     "Graders" or 10 "Generators".
+
+```note
+TODO: Drop the exceptions above?
+```
 
 The CCS must report an error when importing problems that use any
 unsupported features. The CCS may report an error when unsupported keys
@@ -350,7 +354,7 @@ authenticated as admin.
 The CCS must have a mechanism to disable any account (either an account
 for a human user or for another system), without the need for starting
 or stopping the contest. For example, this includes [team
-accounts](#Secure_Authentication) and judge accounts.
+accounts](#secure-authentication) and judge accounts.
 
 ### Changes To Authentication Data
 
@@ -449,7 +453,7 @@ filters of the following types:
     time T<sub>1</sub>.
 6.  All submissions which have been assigned any specific one of the
     allowable submission judgments as defined in [Judge
-    Responses](#Judge_Responses), or all submissions that
+    Responses](#judge-responses), or all submissions that
     received any judgment other than "Accepted" (that is, all rejected
     submissions).
 7.  All submissions which have been run on a specific computer
@@ -468,7 +472,7 @@ or "all submissions using C++".
 The CCS must support the ability to assign, to a single submission, an
 updated judgment chosen from among any of the allowed submission
 judgments as defined in [Judge
-Responses](Contest_Control_System#Judge_Responses).
+Responses](#judge-responses).
 
 The CCS must require a separate authentication every time a judgment is
 changed manually and all such changes must be logged.
@@ -507,7 +511,7 @@ Finalizing is the procedure to authorize the final results at the end of
 a contest. The [results.tsv](#results.tsv) and
 [scoreboard.tsv](#scoreboard.tsv) files will be generated and
 the [finalized](Event_Feed#Finalized_Event) element will be
-sent on the [Event Feeds](Event_Feed).
+sent on the [Event Feeds](event-feed).
 
 When the contest is over, but not finalized, all scoreboards must show a
 warning that the results are not final.
@@ -519,13 +523,13 @@ applies:
 1.  The contest is still running (i.e., the contest is not over).
 2.  There are un-judged submissions.
 3.  There are submissions judged as [Judging
-    Error](#Exception_Judgments).
+    Error](#exceptional-judgments).
 4.  There are unanswered clarification requests.
 
 The following fields need to be entered before Finalizing the contest:
 
 1.  B, a non-negative integer, as used in [Scoring Data
-    Generation](#Scoring_Data_Generation).
+    Generation](#scoring-data-generation).
 2.  a comment, string, that indicates who approves the Final Results,
     for Example "Finalized by John Doe and Jane Doe".
 
@@ -600,7 +604,7 @@ clarification request if any response has occurred yet.
 
 The CCS must ensure that no team can see the clarification requests of
 any other team, except as provided in the section [ Judge
-Interface](Contest_Control_System#Judge_Interface).
+Interface](#judge-interface).
 
 ### Broadcast Messages
 
@@ -608,7 +612,7 @@ Interface](Contest_Control_System#Judge_Interface).
 
 The CCS must provide each team with a capability for viewing any
 broadcast messages sent by the judges (see [ Issuing Broadcast
-Messages](Contest_Control_System#Issuing_Broadcast_Messages)
+Messages](#issuing-broadcast-messages)
 under Judging).
 
 ### Notifications
@@ -683,7 +687,7 @@ the following operations:
 2.  Sort the list of clarification requests by time.
 3.  Filter the list of clarification requests by:
     1.  A user-specified set of
-        [categories](#Clarification_Categories)
+        [categories](#clarification-categories)
     2.  A team
     3.  Whether the clarification request has been answered.
 4.  Determine, for any specific clarification request, what answer was
@@ -720,16 +724,16 @@ automatically:
 
 1.  Compile (if appropriate for the language) the program contained in
     the submission, enforcing the [compilation time
-    limit](Problem_format#limits).
+    limit](https://icpc.io/problem-package-format/spec/problem_package_format#limits).
 2.  Execute the program contained in the submission, with the
     corresponding contest problem data automatically supplied to the
     program.
 3.  Prevent the submitted program from performing any [prohibited
-    operations](#Prohibited_Operations).
+    operations](#prohibited-operations).
 4.  Enforce any configured [execution time
-    limit](Problem_format#limits), [memory
-    limit](Problem_format#limits), and [output size
-    limit](Problem_format#limits) specified for the
+    limit](https://icpc.io/problem-package-format/spec/problem_package_format#limits), [memory
+    limit](https://icpc.io/problem-package-format/spec/problem_package_format#limits), and [output size
+    limit](https://icpc.io/problem-package-format/spec/problem_package_format#limits) specified for the
     corresponding problem.
       - The execution time limit gives a restriction on the amount of
         *CPU time* that the submission may consume, per test file.
@@ -738,12 +742,12 @@ automatically:
         submissions which spend a long time without using CPU time by
         e.g., sleeping).
 5.  Invoke an external program, known for purposes of this document as a
-    [validator](#External_Validators), passing to it the
+    [validator](#external-validators), passing to it the
     output generated by the program specified in the submission and
     getting back from it an indication of what judgment is to be applied
     to the submission (see the [External
-    Validators](#External_Validators) section).
-6.  Assign an [appropriate judgment](#Judge_Responses) to the
+    Validators](#external-validators) section).
+6.  Assign an [appropriate judgment](#judge-responses) to the
     submission.
 7.  Send a notification about the judgement to the team.
 
@@ -801,7 +805,7 @@ The next two sections define how to assign a judgment to a submission
 for problems with a single input file and with multiple input files,
 respectively. Note however that the **Judging Error** and **Security
 Violation** judgments constitute exceptions to this, as defined in
-[Exceptional Judgments](#Exceptional_Judgments).
+[Exceptional Judgments](#exceptional-judgments).
 
 #### Judging With a Single Input File
 
@@ -809,17 +813,17 @@ To determine which answer to use, the following rules must be applied in
 order:
 
 1.  If the submitted program fails to compile or compilation exceeds the
-    [compilation time limit](Problem_format#limits), the
+    [compilation time limit](https://icpc.io/problem-package-format/spec/problem_package_format#limits), the
     response must be **Compile Error**.
 2.  If the submitted program exceeds the [memory
-    limit](Problem_format#limits) or crashes before the
-    [execution time limit](Problem_format#limits) is
+    limit](https://icpc.io/problem-package-format/spec/problem_package_format#limits) or crashes before the
+    [execution time limit](https://icpc.io/problem-package-format/spec/problem_package_format#limits) is
     exceeded, the answer must be **Run-Time Error**.
 3.  If the submitted program runs longer than the [execution time
-    limit](Problem_format#limits), the answer must be **Time
+    limit](https://icpc.io/problem-package-format/spec/problem_package_format#limits), the answer must be **Time
     Limit Exceeded**.
 4.  If the output of the submitted program exceeds the [output size
-    limit](Problem_format#limits) or if the output of the
+    limit](https://icpc.io/problem-package-format/spec/problem_package_format#limits) or if the output of the
     submitted program is not accepted by the output validator, the
     answer must be **Wrong Answer**.
 5.  If the output of the submitted program is accepted by the output
@@ -831,7 +835,7 @@ If the problem has multiple judge input files the judgment is assigned
 as follows:
 
 1.  For each input file apply the [decision process for a single input
-    file](#Judging_With_a_Single_Input_File).
+    file](#judging-with-a-single-input-file).
 2.  If any file is not judged as **Accepted**, the response must be that
     of the first file, in alphabetical order, that was not judged
     **Accepted**.
@@ -849,7 +853,7 @@ program. However, the following two exceptions apply:
     CCS can not recover from, **Judging Error** must be the judgment.
 2.  If, during any point of the judging process the submitted program
     tries to perform a [prohibited
-    operation](#Prohibited_Operations), **Security
+    operation](#prohibited-operations), **Security
     Violation** may be the judgment.
 
 ### Validators
@@ -876,7 +880,7 @@ data according to the following:
     number of minutes elapsed from the beginning of the contest when the
     submission was made, skipping removed time intervals if specified
     (see [Removing Time
-    Intervals](#Removing_time_intervals)). This is rounded
+    Intervals](#removing-time-intervals)). This is rounded
     *down* to the nearest minute, so 59.99 seconds is 0 minutes.
 2.  The *contest time that a team solved a problem* is the contest time
     of the team's first accepted submission to that problem.
@@ -897,7 +901,7 @@ data according to the following:
 7.  The *rank* of a team is then determined as follows:
     1.  For teams in positions up to and including 12+B, the rank equals
         the position (B is provided when [finalizing the
-        contest](#Finalizing_the_Contest); the default value
+        contest](#finalizing-the-contest); the default value
         is 0).
     2.  Teams that solved fewer problems than the median team are not
         ranked at all.
@@ -978,7 +982,7 @@ each ranked team their rank and:
     solved more than the median number of problems).
 2.  The total penalty time and time of last accepted submission, if the
     team is in rank 1 through 12+B (where B is as defined in [Scoring
-    Data Generation](#Scoring_Data_Generation)).
+    Data Generation](#scoring-data-generation)).
 
 The CCS must be capable of generating an external file containing the
 final results of the World Finals contest. The format of this file must
@@ -1044,7 +1048,7 @@ functions while communicating only with the Primary CCS.
 
 A CCS running in shadow mode must be able to import a complete contest
 configuration as described in the [Importing Contest
-Configuration](#Importing_Contest_Configuration) section of
+Configuration](#importing-contest-configuration) section of
 this Requirements Specification. In particular a shadow-mode CCS must be
 able to import a contest configuration from a single URL and must also
 be able to import the teams.tsv and groups.tsv files as specified in
@@ -1060,14 +1064,14 @@ specification](Draft_CCS_REST_interface). The following
 requirements then apply to the mechanisms used by the Shadow CCS for
 obtaining submissions:
 
-1.  The Shadow CCS should use the **/event-feed** REST endpoint defined
+1.  The Shadow CCS should use the `/event-feed` REST endpoint defined
     in the [CLICS CCS REST interface
     specification](Draft_CCS_REST_interface) to obtain
     notification of team submissions from the Primary CCS (in other
     words, the Shadow CCS should preferably use event-driven operation,
     rather than polling, for team submission notification).
-2.  The Shadow CCS must use the **/submissions/<id>** and
-    **/submissions/<id>/files** REST endpoints defined in the [CLICS CCS
+2.  The Shadow CCS must use the `/submissions/<id>` and
+    `/submissions/<id>/files` REST endpoints defined in the [CLICS CCS
     REST interface specification](Draft_CCS_REST_interface)
     for obtaining submission data from the Primary CCS.
 3.  The Shadow CCS must provide an interface that can display
@@ -1085,8 +1089,8 @@ obtaining submissions:
 
 A CCS running in shadow mode must produce the same set of output files
 as those required of a Primary CCS -- that is, it must produce at least
-the [scoreboard.tsv](#scoreboard.tsv) and
-[results.tsv](#results.tsv) files as defined elsewhere in
+the [scoreboard.tsv](#scoreboardtsv) and
+[results.tsv](#resultstsv) files as defined elsewhere in
 this Requirements Specification.
 
 A CCS running in shadow mode must in addition provide the capability to
@@ -1120,7 +1124,7 @@ In order for a given CCS to be considered as a candidate for running the
 ICPC World Finals contest, the following documents must be submitted.
 
   - A text file named "License" containing the license, conforming to
-    the the [Licensing](#Licensing) section, under which the
+    the the [Licensing](#licensing) section, under which the
     CCS is made available to the ICPC.
   - A *Requirements Compliance Document* as defined below.
   - A *Team Guide* as defined below.
@@ -1396,11 +1400,11 @@ Then follow several lines with the following format (one per account).
 | 3     | Username     | austrin     | string |
 | 4     | Password     | B\!5MWJiy   | string |
 
-Account Types are: **team**, **judge**, **admin**, **analyst**.
+Account Types are: `team`, `judge`, `admin`, `analyst`.
 
-For accounts of type **team** username is on the form "team-nnn" where
+For accounts of type `team` username is on the form "team-nnn" where
 "nnn" is the zero padded team number as given in
-[teams.tsv](#teams.tsv).
+[teams.tsv](#teamstsv).
 
 #### logos.tar.gz
 
@@ -1449,7 +1453,7 @@ Then follow several lines with the following format (one per team).
 |              |                                        |                        |         |
 
 The External ID for a team can be found in the
-[teams.tsv](#teams.tsv).
+[teams.tsv](#teamstsv).
 
 The time when problem was solved must be -1 if the problem was not
 solved.
@@ -1489,14 +1493,14 @@ Group Winner is a string with the name of the group if the team is the
 group winner, otherwise empty.
 
 The External ID for a team can be found in the
-[teams.tsv](#teams.tsv).
+[teams.tsv](#teamstsv).
 
 If the team is not ranked (has no assigned rank) then the Rank in
 contest field is empty.
 
 Award is a string with value "Gold Medal", "Silver Medal", "Bronze
 Medal", "Ranked" or "Honorable" as appropriate, see [Scoring Data
-Generation](#Scoring_Data_Generation) for details.
+Generation](#scoring-data-generation) for details.
 
 #### submissions.tsv
 

--- a/Contest_Control_System_Requirements.md
+++ b/Contest_Control_System_Requirements.md
@@ -492,7 +492,7 @@ freeze time must be treated as pending on a frozen scoreboard.
 
 The exact phrase displayed on the frozen scoreboard must be:
 
-` The scoreboard was frozen with XX minutes remaining - submissions in the last XX minutes of the contest are still shown as pending.`
+` The scoreboard was frozen with XX minutes remaining - submissions in the last XX minutes of the contest are still shown as pending.`
 
 where XX is the number of minutes remaining in the contest at the time
 the scoreboard was frozen.
@@ -1209,14 +1209,14 @@ A YAML file consisting of a mapping with the following keys:
 ##### Example
 
 ```yaml
-# Contest configuration  
+# Contest configuration  
 ---  
-name:                     ICPC World Finals 2011  
-short-name:               ICPC WF 2011  
-start-time:               2011-02-04T01:23:00Z  
-duration:                 5:00:00  
-scoreboard-freeze-length: 1:00:00  
-penalty-time:             20
+name:                     ICPC World Finals 2011  
+short-name:               ICPC WF 2011  
+start-time:               2011-02-04T01:23:00Z  
+duration:                 5:00:00  
+scoreboard-freeze-length: 1:00:00  
+penalty-time:             20
 ```
 
 #### system.yaml
@@ -1252,31 +1252,31 @@ place as few restrictions as possible on the language configuration.
 ##### Example
 
 ```yaml
-# System configuration  
+# System configuration  
 ---  
 default-clars:  
-  - No comment, read problem statement.  
-  - This will be answered during the answers to questions session.  
+  - No comment, read problem statement.  
+  - This will be answered during the answers to questions session.  
   
 clar-categories:  
-  - General  
-  - SysOps  
-  - Operations  
+  - General  
+  - SysOps  
+  - Operations  
   
 languages:  
-  - name: C++  
-    compiler: /usr/bin/g++    
-    compiler-args: -O2 -Wall -o a.out -static {files}   
+  - name: C++  
+    compiler: /usr/bin/g++    
+    compiler-args: -O2 -Wall -o a.out -static {files}   
   
-  - name: C  
-    compiler: /usr/bin/gcc  
-    compiler-args: -O2 -Wall -std=gnu99 -o a.out -static {files} -lm  
-    
-  - name: Java  
-    compiler: /usr/bin/javac  
-    compiler-args: -O {files}  
-    runner: /usr/bin/java  
-    runner-args:
+  - name: C  
+    compiler: /usr/bin/gcc  
+    compiler-args: -O2 -Wall -std=gnu99 -o a.out -static {files} -lm  
+    
+  - name: Java  
+    compiler: /usr/bin/javac  
+    compiler-args: -O {files}  
+    runner: /usr/bin/java  
+    runner-args:
 ```
 
 #### problemset.yaml
@@ -1301,33 +1301,33 @@ A sequence of mappings with the following keys:
 ##### Example
 
 ```yaml
-# Problem set configuration  
----   
+# Problem set configuration  
+---   
 problems:  
-  - letter:     A  
-    short-name: apl  
-    color:      yellow  
-    rgb:        '#ffff00'  
-    
-  - letter:     B  
-    short-name: barcodes  
-    color:      red  
-    rgb:        '#ff0000'  
-    
-  - letter:     C  
-    short-name: biobots  
-    color:      green  
-    rgb:        '#00ff00'  
-    
-  - letter:     D  
-    short-name: castles  
-    color:      blue  
-    rgb:        '#0000ff'  
-    
-  - letter:     E  
-    short-name: channel  
-    color:      white  
-    rgb:        '#ffffff'
+  - letter:     A  
+    short-name: apl  
+    color:      yellow  
+    rgb:        '#ffff00'  
+    
+  - letter:     B  
+    short-name: barcodes  
+    color:      red  
+    rgb:        '#ff0000'  
+    
+  - letter:     C  
+    short-name: biobots  
+    color:      green  
+    rgb:        '#00ff00'  
+    
+  - letter:     D  
+    short-name: castles  
+    color:      blue  
+    rgb:        '#0000ff'  
+    
+  - letter:     E  
+    short-name: channel  
+    color:      white  
+    rgb:        '#ffffff'
 ```
 
 #### groups.tsv

--- a/Contest_Control_System_Requirements.md
+++ b/Contest_Control_System_Requirements.md
@@ -1209,13 +1209,13 @@ A YAML file consisting of a mapping with the following keys:
 ##### Example
 
 ```yaml
-# Contest configuration  
----  
-name:                     ICPC World Finals 2011  
-short-name:               ICPC WF 2011  
-start-time:               2011-02-04T01:23:00Z  
-duration:                 5:00:00  
-scoreboard-freeze-length: 1:00:00  
+# Contest configuration
+---
+name:                     ICPC World Finals 2011
+short-name:               ICPC WF 2011
+start-time:               2011-02-04T01:23:00Z
+duration:                 5:00:00
+scoreboard-freeze-length: 1:00:00
 penalty-time:             20
 ```
 
@@ -1252,30 +1252,30 @@ place as few restrictions as possible on the language configuration.
 ##### Example
 
 ```yaml
-# System configuration  
----  
-default-clars:  
-  - No comment, read problem statement.  
-  - This will be answered during the answers to questions session.  
-  
-clar-categories:  
-  - General  
-  - SysOps  
-  - Operations  
-  
-languages:  
-  - name: C++  
-    compiler: /usr/bin/g++    
-    compiler-args: -O2 -Wall -o a.out -static {files}   
-  
-  - name: C  
-    compiler: /usr/bin/gcc  
-    compiler-args: -O2 -Wall -std=gnu99 -o a.out -static {files} -lm  
-    
-  - name: Java  
-    compiler: /usr/bin/javac  
-    compiler-args: -O {files}  
-    runner: /usr/bin/java  
+# System configuration
+---
+default-clars:
+  - No comment, read problem statement.
+  - This will be answered during the answers to questions session.
+
+clar-categories:
+  - General
+  - SysOps
+  - Operations
+
+languages:
+  - name: C++
+    compiler: /usr/bin/g++
+    compiler-args: -O2 -Wall -o a.out -static {files}
+
+  - name: C
+    compiler: /usr/bin/gcc
+    compiler-args: -O2 -Wall -std=gnu99 -o a.out -static {files} -lm
+
+  - name: Java
+    compiler: /usr/bin/javac
+    compiler-args: -O {files}
+    runner: /usr/bin/java
     runner-args:
 ```
 
@@ -1301,32 +1301,32 @@ A sequence of mappings with the following keys:
 ##### Example
 
 ```yaml
-# Problem set configuration  
----   
-problems:  
-  - letter:     A  
-    short-name: apl  
-    color:      yellow  
-    rgb:        '#ffff00'  
-    
-  - letter:     B  
-    short-name: barcodes  
-    color:      red  
-    rgb:        '#ff0000'  
-    
-  - letter:     C  
-    short-name: biobots  
-    color:      green  
-    rgb:        '#00ff00'  
-    
-  - letter:     D  
-    short-name: castles  
-    color:      blue  
-    rgb:        '#0000ff'  
-    
-  - letter:     E  
-    short-name: channel  
-    color:      white  
+# Problem set configuration
+---
+problems:
+  - letter:     A
+    short-name: apl
+    color:      yellow
+    rgb:        '#ffff00'
+
+  - letter:     B
+    short-name: barcodes
+    color:      red
+    rgb:        '#ff0000'
+
+  - letter:     C
+    short-name: biobots
+    color:      green
+    rgb:        '#00ff00'
+
+  - letter:     D
+    short-name: castles
+    color:      blue
+    rgb:        '#0000ff'
+
+  - letter:     E
+    short-name: channel
+    color:      white
     rgb:        '#ffffff'
 ```
 

--- a/Contest_Control_System_Requirements.md
+++ b/Contest_Control_System_Requirements.md
@@ -42,7 +42,7 @@ A contest control system may be submitted to the Director of Operations
 for the ICPC World Finals for consideration as a candidate to run the
 World Finals. The items which must be submitted in order to be
 considered are described under [ Certification
-Process](#Certification_Process "wikilink") in this document. Any
+Process](#Certification_Process) in this document. Any
 submitted CCS which meets all of the requirements defined in this
 document will be certified as being accepted as a candidate to run the
 World Finals. Meeting or failing to meet each requirement will be
@@ -124,22 +124,22 @@ At least the following different types of accounts must be supported:
 
   - Team: used by teams competing in the contest. The functions
     available to team clients are as defined in the section on the [team
-    interface](#Team_Interface "wikilink").
+    interface](#Team_Interface).
 
   - Judge: used by judges in the contest. The functions available to
     judge clients are as defined in the section on the [judge
-    interface](#Judge_Interface "wikilink").
+    interface](#Judge_Interface).
 
   - Admin: used by contest administrators. The functions available to
     admin clients are as defined in the section on the [admin
-    interface](#Admin_Interface "wikilink").
+    interface](#Admin_Interface).
 
 ### Secure Authentication
 
 The CCS must support a secure authentication mechanism, allowing each
-registered user (being either a [team](#Team_Interface "wikilink"), an
-[admin](#Admin_Interface "wikilink"), or a
-[judge](#Judge_Interface "wikilink")) to gain access to the contest, and
+registered user (being either a [team](#Team_Interface), an
+[admin](#Admin_Interface), or a
+[judge](#Judge_Interface)) to gain access to the contest, and
 must ensure that:
 
 1.  Only users who supply correct authentication credentials may invoke
@@ -162,9 +162,9 @@ If the CCS uses a login/password mechanism to enforce secure
 authentication, it must support account creation and password assignment
 according to the following algorithm:
 
-1.  read [teams.tsv](#teams.tsv "wikilink") defining team accounts to be
+1.  read [teams.tsv](#teams.tsv) defining team accounts to be
     created
-2.  read [ accounts.tsv](#accounts.tsv "wikilink") defining additional
+2.  read [ accounts.tsv](#accounts.tsv) defining additional
     accounts to be created or, for teams, specifying the password of the
     accounts.
 
@@ -249,21 +249,21 @@ be required to make any changes once the contest starts.
 The CCS must be able to import contest configuration from a single URL,
 and use the data at that location to configure the CCS. The
 configuration URL contains all contest configuration data, including the
-contest configuration file ([contest.yaml](#contest.yaml "wikilink")),
+contest configuration file ([contest.yaml](#contest.yaml)),
 problemset configuration file
-([problemset.yaml](#problemset.yaml "wikilink")), problem definitions,
+([problemset.yaml](#problemset.yaml)), problem definitions,
 teams.tsv, groups.tsv and logos.tar.gz. For example, if the URL is
 <http://10.1.1.0/data>, teams.tsv can be imported from
 <http://10.1.1.0/data/teams.tsv>.
 
-The CCS must be able to read [teams.tsv](#teams.tsv "wikilink"), which
+The CCS must be able to read [teams.tsv](#teams.tsv), which
 contains a list of teams registered for the World Finals. It must use
 the data in this file to automatically create whatever internal
 representation is necessary to allow each team (and only the teams)
 specified in the registration list to participate in the World Finals
 contest.
 
-The CCS must be able to read [groups.tsv](#groups.tsv "wikilink"), an
+The CCS must be able to read [groups.tsv](#groups.tsv), an
 initialization file containing the list of groups to which the teams
 belong.
 
@@ -277,7 +277,7 @@ on the contest network.
 The CCS must be able to configure predefined answers to clarification
 requests (e.g., "No response, read problem statement." and "This will be
 answered after the practice session.") from the [ contest configuration
-file](#contest.yaml "wikilink"), so that judges can choose to reply to a
+file](#contest.yaml), so that judges can choose to reply to a
 clarification request by selecting a predefined answer rather than being
 required to enter a specific answer. One of the predefined answers must
 be the "default" answer.
@@ -286,7 +286,7 @@ be the "default" answer.
 
 The CCS must be able to configure "categories" to which clarification
 requests can be assigned from the [ contest configuration
-file](#contest.yaml "wikilink"). A request belongs to exactly one
+file](#contest.yaml). A request belongs to exactly one
 category. Examples of categories are "General", "SysOps", "Operations".
 
 In addition, the CCS must construct one category per problem, i.e.,
@@ -311,7 +311,7 @@ the compiler or interpreter's documentation.
 
 Problems (including judge data, validators, execution time limit, etc)
 are specified and configured using the [Problem
-format](Problem_format "wikilink"). The CCS must support this format
+format](Problem_format). The CCS must support this format
 with the following exceptions:
 
   - The CCS does not have to support the use of the following keys in
@@ -350,7 +350,7 @@ authenticated as admin.
 The CCS must have a mechanism to disable any account (either an account
 for a human user or for another system), without the need for starting
 or stopping the contest. For example, this includes [team
-accounts](#Secure_Authentication "wikilink") and judge accounts.
+accounts](#Secure_Authentication) and judge accounts.
 
 ### Changes To Authentication Data
 
@@ -376,7 +376,7 @@ in wall-clock time.
 
 Note that removing a time interval changes the wall-clock time when the
 contest ends, as the duration of the contest in
-[contest.yaml](#contest.yaml "wikilink") is specified in contest time.
+[contest.yaml](#contest.yaml) is specified in contest time.
 
 Removing the interval between time T<sub>0</sub> and T<sub>1</sub>,
 where T<sub>0</sub> ≤ T<sub>1</sub>, means that all submissions received
@@ -449,7 +449,7 @@ filters of the following types:
     time T<sub>1</sub>.
 6.  All submissions which have been assigned any specific one of the
     allowable submission judgments as defined in [Judge
-    Responses](#Judge_Responses "wikilink"), or all submissions that
+    Responses](#Judge_Responses), or all submissions that
     received any judgment other than "Accepted" (that is, all rejected
     submissions).
 7.  All submissions which have been run on a specific computer
@@ -468,7 +468,7 @@ or "all submissions using C++".
 The CCS must support the ability to assign, to a single submission, an
 updated judgment chosen from among any of the allowed submission
 judgments as defined in [Judge
-Responses](Contest_Control_System#Judge_Responses "wikilink").
+Responses](Contest_Control_System#Judge_Responses).
 
 The CCS must require a separate authentication every time a judgment is
 changed manually and all such changes must be logged.
@@ -504,10 +504,10 @@ affecting contest operations in any way.
 ### Finalizing the Contest
 
 Finalizing is the procedure to authorize the final results at the end of
-a contest. The [results.tsv](#results.tsv "wikilink") and
-[scoreboard.tsv](#scoreboard.tsv "wikilink") files will be generated and
-the [finalized](Event_Feed#Finalized_Event "wikilink") element will be
-sent on the [Event Feeds](Event_Feed "wikilink").
+a contest. The [results.tsv](#results.tsv) and
+[scoreboard.tsv](#scoreboard.tsv) files will be generated and
+the [finalized](Event_Feed#Finalized_Event) element will be
+sent on the [Event Feeds](Event_Feed).
 
 When the contest is over, but not finalized, all scoreboards must show a
 warning that the results are not final.
@@ -519,13 +519,13 @@ applies:
 1.  The contest is still running (i.e., the contest is not over).
 2.  There are un-judged submissions.
 3.  There are submissions judged as [Judging
-    Error](#Exception_Judgments "wikilink").
+    Error](#Exception_Judgments).
 4.  There are unanswered clarification requests.
 
 The following fields need to be entered before Finalizing the contest:
 
 1.  B, a non-negative integer, as used in [Scoring Data
-    Generation](#Scoring_Data_Generation "wikilink").
+    Generation](#Scoring_Data_Generation).
 2.  a comment, string, that indicates who approves the Final Results,
     for Example "Finalized by John Doe and Jane Doe".
 
@@ -600,7 +600,7 @@ clarification request if any response has occurred yet.
 
 The CCS must ensure that no team can see the clarification requests of
 any other team, except as provided in the section [ Judge
-Interface](Contest_Control_System#Judge_Interface "wikilink").
+Interface](Contest_Control_System#Judge_Interface).
 
 ### Broadcast Messages
 
@@ -608,7 +608,7 @@ Interface](Contest_Control_System#Judge_Interface "wikilink").
 
 The CCS must provide each team with a capability for viewing any
 broadcast messages sent by the judges (see [ Issuing Broadcast
-Messages](Contest_Control_System#Issuing_Broadcast_Messages "wikilink")
+Messages](Contest_Control_System#Issuing_Broadcast_Messages)
 under Judging).
 
 ### Notifications
@@ -683,7 +683,7 @@ the following operations:
 2.  Sort the list of clarification requests by time.
 3.  Filter the list of clarification requests by:
     1.  A user-specified set of
-        [categories](#Clarification_Categories "wikilink")
+        [categories](#Clarification_Categories)
     2.  A team
     3.  Whether the clarification request has been answered.
 4.  Determine, for any specific clarification request, what answer was
@@ -720,16 +720,16 @@ automatically:
 
 1.  Compile (if appropriate for the language) the program contained in
     the submission, enforcing the [compilation time
-    limit](Problem_format#limits "wikilink").
+    limit](Problem_format#limits).
 2.  Execute the program contained in the submission, with the
     corresponding contest problem data automatically supplied to the
     program.
 3.  Prevent the submitted program from performing any [prohibited
-    operations](#Prohibited_Operations "wikilink").
+    operations](#Prohibited_Operations).
 4.  Enforce any configured [execution time
-    limit](Problem_format#limits "wikilink"), [memory
-    limit](Problem_format#limits "wikilink"), and [output size
-    limit](Problem_format#limits "wikilink") specified for the
+    limit](Problem_format#limits), [memory
+    limit](Problem_format#limits), and [output size
+    limit](Problem_format#limits) specified for the
     corresponding problem.
       - The execution time limit gives a restriction on the amount of
         *CPU time* that the submission may consume, per test file.
@@ -738,12 +738,12 @@ automatically:
         submissions which spend a long time without using CPU time by
         e.g., sleeping).
 5.  Invoke an external program, known for purposes of this document as a
-    [validator](#External_Validators "wikilink"), passing to it the
+    [validator](#External_Validators), passing to it the
     output generated by the program specified in the submission and
     getting back from it an indication of what judgment is to be applied
     to the submission (see the [External
-    Validators](#External_Validators "wikilink") section).
-6.  Assign an [appropriate judgment](#Judge_Responses "wikilink") to the
+    Validators](#External_Validators) section).
+6.  Assign an [appropriate judgment](#Judge_Responses) to the
     submission.
 7.  Send a notification about the judgement to the team.
 
@@ -801,7 +801,7 @@ The next two sections define how to assign a judgment to a submission
 for problems with a single input file and with multiple input files,
 respectively. Note however that the **Judging Error** and **Security
 Violation** judgments constitute exceptions to this, as defined in
-[Exceptional Judgments](#Exceptional_Judgments "wikilink").
+[Exceptional Judgments](#Exceptional_Judgments).
 
 #### Judging With a Single Input File
 
@@ -809,17 +809,17 @@ To determine which answer to use, the following rules must be applied in
 order:
 
 1.  If the submitted program fails to compile or compilation exceeds the
-    [compilation time limit](Problem_format#limits "wikilink"), the
+    [compilation time limit](Problem_format#limits), the
     response must be **Compile Error**.
 2.  If the submitted program exceeds the [memory
-    limit](Problem_format#limits "wikilink") or crashes before the
-    [execution time limit](Problem_format#limits "wikilink") is
+    limit](Problem_format#limits) or crashes before the
+    [execution time limit](Problem_format#limits) is
     exceeded, the answer must be **Run-Time Error**.
 3.  If the submitted program runs longer than the [execution time
-    limit](Problem_format#limits "wikilink"), the answer must be **Time
+    limit](Problem_format#limits), the answer must be **Time
     Limit Exceeded**.
 4.  If the output of the submitted program exceeds the [output size
-    limit](Problem_format#limits "wikilink") or if the output of the
+    limit](Problem_format#limits) or if the output of the
     submitted program is not accepted by the output validator, the
     answer must be **Wrong Answer**.
 5.  If the output of the submitted program is accepted by the output
@@ -831,7 +831,7 @@ If the problem has multiple judge input files the judgment is assigned
 as follows:
 
 1.  For each input file apply the [decision process for a single input
-    file](#Judging_With_a_Single_Input_File "wikilink").
+    file](#Judging_With_a_Single_Input_File).
 2.  If any file is not judged as **Accepted**, the response must be that
     of the first file, in alphabetical order, that was not judged
     **Accepted**.
@@ -849,7 +849,7 @@ program. However, the following two exceptions apply:
     CCS can not recover from, **Judging Error** must be the judgment.
 2.  If, during any point of the judging process the submitted program
     tries to perform a [prohibited
-    operation](#Prohibited_Operations "wikilink"), **Security
+    operation](#Prohibited_Operations), **Security
     Violation** may be the judgment.
 
 ### Validators
@@ -876,13 +876,13 @@ data according to the following:
     number of minutes elapsed from the beginning of the contest when the
     submission was made, skipping removed time intervals if specified
     (see [Removing Time
-    Intervals](#Removing_time_intervals "wikilink")). This is rounded
+    Intervals](#Removing_time_intervals)). This is rounded
     *down* to the nearest minute, so 59.99 seconds is 0 minutes.
 2.  The *contest time that a team solved a problem* is the contest time
     of the team's first accepted submission to that problem.
 3.  A team's *penalty time on a problem* is the contest time that the
     team solved the problem, plus *penaltytime* (from
-    [contest.yaml](#contest.yaml "wikilink")) minutes for each previous
+    [contest.yaml](#contest.yaml)) minutes for each previous
     submission rejected with a judgement that causes penalty time, by
     that team on that problem, or 0 if the team has not solved the
     problem.
@@ -897,7 +897,7 @@ data according to the following:
 7.  The *rank* of a team is then determined as follows:
     1.  For teams in positions up to and including 12+B, the rank equals
         the position (B is provided when [finalizing the
-        contest](#Finalizing_the_Contest "wikilink"); the default value
+        contest](#Finalizing_the_Contest); the default value
         is 0).
     2.  Teams that solved fewer problems than the median team are not
         ranked at all.
@@ -930,7 +930,7 @@ The scoreboard must include at least the following information.
 For each team:
 
 1.  university name
-2.  univerisity logo (see [logos.tar.gz](#logos.tar.gz "wikilink"))
+2.  univerisity logo (see [logos.tar.gz](#logos.tar.gz))
 3.  team position
 4.  number of problems solved
 5.  total penalty time
@@ -955,13 +955,13 @@ It is a requirement that the CCS provide an *external event feed*. This
 means that the CCS must have a mechanism for external processes to
 connect to the CCS and obtain dynamic real-time updates regarding the
 current state of the contest. The CCS event feed mechanism must comply
-with the [Event Feed specification](Event_Feed "wikilink").
+with the [Event Feed specification](Event_Feed).
 
 ### Scoreboard Data File
 
 The CCS must be capable of generating an external file containing the
 current scoreboard. The format of this file must be as defined in
-[scoreboard.tsv](#scoreboard.tsv "wikilink").
+[scoreboard.tsv](#scoreboard.tsv).
 
 The CCS must automatically save an updated copy of the external scoring
 data file whenever the scoring data itself is updated as described
@@ -978,11 +978,11 @@ each ranked team their rank and:
     solved more than the median number of problems).
 2.  The total penalty time and time of last accepted submission, if the
     team is in rank 1 through 12+B (where B is as defined in [Scoring
-    Data Generation](#Scoring_Data_Generation "wikilink")).
+    Data Generation](#Scoring_Data_Generation)).
 
 The CCS must be capable of generating an external file containing the
 final results of the World Finals contest. The format of this file must
-be as defined in the [results.tsv](#results.tsv "wikilink").
+be as defined in the [results.tsv](#results.tsv).
 
 ## Shadow Mode
 
@@ -1044,7 +1044,7 @@ functions while communicating only with the Primary CCS.
 
 A CCS running in shadow mode must be able to import a complete contest
 configuration as described in the [Importing Contest
-Configuration](#Importing_Contest_Configuration "wikilink") section of
+Configuration](#Importing_Contest_Configuration) section of
 this Requirements Specification. In particular a shadow-mode CCS must be
 able to import a contest configuration from a single URL and must also
 be able to import the teams.tsv and groups.tsv files as specified in
@@ -1056,19 +1056,19 @@ A CCS running in shadow mode must be able to obtain team submissions via
 communication with the Primary CCS. As required elsewhere in this
 specification, the Primary CCS must implement the REST endpoints defined
 in the [CLICS CCS REST interface
-specification](Draft_CCS_REST_interface "wikilink"). The following
+specification](Draft_CCS_REST_interface). The following
 requirements then apply to the mechanisms used by the Shadow CCS for
 obtaining submissions:
 
 1.  The Shadow CCS should use the **/event-feed** REST endpoint defined
     in the [CLICS CCS REST interface
-    specification](Draft_CCS_REST_interface "wikilink") to obtain
+    specification](Draft_CCS_REST_interface) to obtain
     notification of team submissions from the Primary CCS (in other
     words, the Shadow CCS should preferably use event-driven operation,
     rather than polling, for team submission notification).
 2.  The Shadow CCS must use the **/submissions/<id>** and
     **/submissions/<id>/files** REST endpoints defined in the [CLICS CCS
-    REST interface specification](Draft_CCS_REST_interface "wikilink")
+    REST interface specification](Draft_CCS_REST_interface)
     for obtaining submission data from the Primary CCS.
 3.  The Shadow CCS must provide an interface that can display
     information regarding any submission by looking up the submission
@@ -1085,8 +1085,8 @@ obtaining submissions:
 
 A CCS running in shadow mode must produce the same set of output files
 as those required of a Primary CCS -- that is, it must produce at least
-the [scoreboard.tsv](#scoreboard.tsv "wikilink") and
-[results.tsv](#results.tsv "wikilink") files as defined elsewhere in
+the [scoreboard.tsv](#scoreboard.tsv) and
+[results.tsv](#results.tsv) files as defined elsewhere in
 this Requirements Specification.
 
 A CCS running in shadow mode must in addition provide the capability to
@@ -1120,7 +1120,7 @@ In order for a given CCS to be considered as a candidate for running the
 ICPC World Finals contest, the following documents must be submitted.
 
   - A text file named "License" containing the license, conforming to
-    the the [Licensing](#Licensing "wikilink") section, under which the
+    the the [Licensing](#Licensing) section, under which the
     CCS is made available to the ICPC.
   - A *Requirements Compliance Document* as defined below.
   - A *Team Guide* as defined below.
@@ -1400,7 +1400,7 @@ Account Types are: **team**, **judge**, **admin**, **analyst**.
 
 For accounts of type **team** username is on the form "team-nnn" where
 "nnn" is the zero padded team number as given in
-[teams.tsv](#teams.tsv "wikilink").
+[teams.tsv](#teams.tsv).
 
 #### logos.tar.gz
 
@@ -1449,7 +1449,7 @@ Then follow several lines with the following format (one per team).
 |              |                                        |                        |         |
 
 The External ID for a team can be found in the
-[teams.tsv](#teams.tsv "wikilink").
+[teams.tsv](#teams.tsv).
 
 The time when problem was solved must be -1 if the problem was not
 solved.
@@ -1489,14 +1489,14 @@ Group Winner is a string with the name of the group if the team is the
 group winner, otherwise empty.
 
 The External ID for a team can be found in the
-[teams.tsv](#teams.tsv "wikilink").
+[teams.tsv](#teams.tsv).
 
 If the team is not ranked (has no assigned rank) then the Rank in
 contest field is empty.
 
 Award is a string with value "Gold Medal", "Silver Medal", "Bronze
 Medal", "Ranked" or "Honorable" as appropriate, see [Scoring Data
-Generation](#Scoring_Data_Generation "wikilink") for details.
+Generation](#Scoring_Data_Generation) for details.
 
 #### submissions.tsv
 


### PR DESCRIPTION
This should fix all in-page links. Fixed a few other links as well, but left most broken links to now deleted documents in place.

Also changed some things from **bold** to `code` font where I though it appropriate, but feel free to disagree.

If all is well, CI should be working now and put a green check mark next to the last commit in the chain. There will be 2 links: one to the preview site (click `details` to open), and the other one to the CI logs in my private mirroring repository.

Also note that repository mirroring has a delay of up to 30 mins for free plans.