### PR TITLE
Fix Baylor URLs and switch to Contest API

### DIFF
--- a/Contest_Control_System_Requirements.md
+++ b/Contest_Control_System_Requirements.md
@@ -8,8 +8,8 @@ permalink: /ccs_system_requirements
 This document specifies requirements for operation, verification and
 validation of Programming Contest Control Systems that wish to be
 considered for managing the operation of the [International
-Collegiate Programming Contest](http://icpc.baylor.edu) [World
-Finals](http://cm.baylor.edu/ICPCWiki/Wiki.jsp?page=World%20Finals). The
+Collegiate Programming Contest](https://icpc.global) [World
+Finals](https://icpc.global/worldfinals/schedule). The
 document defines a set of operations, capabilities, and features which
 any candidate system must provide, including a set of testability
 criteria which must be satisfied and a set of documentation which must
@@ -299,7 +299,7 @@ categories named e.g. "Problem A", "Problem B", etc. for each problem.
 The CCS must provide the ability to compile and execute (or interpret,
 as appropriate for the language) submitted source code files for each of
 the languages specified by the [Environment of the World
-Finals](http://icpc.baylor.edu/worldfinals/programming-environment).
+Finals](https://icpc.global/worldfinals/programming-environment).
 
 #### Language Options
 

--- a/Contest_Control_System_Requirements.md
+++ b/Contest_Control_System_Requirements.md
@@ -953,13 +953,13 @@ problem.
 
 ## Data Export
 
-### Event Feed
+### Contest API
 
-It is a requirement that the CCS provide an *external event feed*. This
+It is a requirement that the CCS provide an external *Contest API*. This
 means that the CCS must have a mechanism for external processes to
 connect to the CCS and obtain dynamic real-time updates regarding the
-current state of the contest. The CCS event feed mechanism must comply
-with the [Event Feed specification](Event_Feed).
+current state of the contest. The CCS mechanism must comply
+with the [Contest API specification](../contest_api).
 
 ### Scoreboard Data File
 


### PR DESCRIPTION
Minor URL fix, plus switch references from event feed to Contest API. This is really just changing a couple references, we still need to talk about the broader Contest API / contest archive / file format use throughout this spec.