### PR TITLE
Add support for POSTing submissions.

### DIFF
--- a/Contest_API.md
+++ b/Contest_API.md
@@ -1072,15 +1072,21 @@ endpoint returns with a `GET` request with the following exceptions:
   the ID of the team associated with the request and `time` will always use
   the current time as determined by the server. The CCS will determine an `id`.
 * If an `id` is supplied, the client should make sure it is unique, i.e. not used
-  yet on the CCS.
+  yet on the CCS. The client should normally not supply `id`, but let it be determined
+  by the server. However, for example in a setup with a central CCS with satellite sites
+  where teams submit to a proxy CCS that forwards to the central CCS, this might be
+  useful to make sure that the proxy CCS can accept submissions even when the connection
+  to the central CCS is down. The proxy can then forward these submissions later, when
+  the connection is restored again.
 
 The request should fail with a 400 if any of the following happens:
 
-* A required attribute is msising.
+* A required attribute is missing.
 * The supplied problem, team or language can not be found.
 * An entrypoint is required for the given language, but not supplied.
 * Something is wrong with the submission file. For example it contains too many
   files, it is too big, etc.
+* The provided `id` already exists.
 
 The response will be the ID of the newly added submission.
 

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -1108,7 +1108,6 @@ Request data:
    "team_id": "123",
    "time": "2014-06-25T11:22:05.034+01",
    "entry_point": "Main",
-   "start_time": "2014-06-25T10:00:00+01",
    "files": [{"data": "<base64 string>"}]
 }
 ```

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -1062,19 +1062,19 @@ To add submissions one can use the `POST` method on the submissions endpoint.
 The `POST` must include a valid JSON object with the same attributes the submission
 endpoint returns with a `GET` request with the following exceptions:
 
-* Any provided `id`, `reaction` and `contest_time` attributes are ignored.
+* `id`, `reaction` and `contest_time` should not be provided, and are ignored.
 * The `time` attribute is optional. If not provided (or `null`) it will default
   to the current time as determined by the server.
 * Since `files` only supports `application/zip`, providing the `mime` field is
   optional.
 * If the CCS supports a `team` role, the `team_id` and `time`
-  attributes will be ignored when using a this role. `team_id` will then use
+  attributes will be ignored when using this role. `team_id` will then be set to
   the ID of the team associated with the request and `time` will always use
   the current time as determined by the server.
 
 The response will be the ID of the newly added submission.
 
-The `public` role can never add submissions.
+Performing a `POST` by any other roles than `admin` and `team` are not supported.
 
 #### Example
 

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -1058,7 +1058,7 @@ not frozen.
 
 #### POST submissions
 
-To add submissions one can use the `POST` method on the submissions endpoint.
+To add a submission one can use the `POST` method on the submissions endpoint.
 The `POST` must include a valid JSON object with the same attributes the submission
 endpoint returns with a `GET` request with the following exceptions:
 
@@ -1080,7 +1080,7 @@ endpoint returns with a `GET` request with the following exceptions:
   to the central CCS is down. The proxy can then forward these submissions later, when
   the connection is restored again.
 
-The request should fail with a 400 if any of the following happens:
+The request must fail with a 400 error code if any of the following happens:
 
 * A required attribute is missing.
 * An attribute that must not be provided is provided.
@@ -1088,7 +1088,7 @@ The request should fail with a 400 if any of the following happens:
 * An entrypoint is required for the given language, but not supplied.
 * Something is wrong with the submission file. For example it contains too many
   files, it is too big, etc.
-* The provided `id` already exists.
+* The provided `id` already exists or is otherwise not acceptable.
 
 The response will be the ID of the newly added submission.
 

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -1059,31 +1059,20 @@ not frozen.
 #### POST submissions
 
 To add submissions one can use the `POST` method on the submissions endpoint.
-The `POST` must include a valid JSON object with the following attributes:
+The `POST` must include a valid JSON object with the same attributes the submission
+endpoint returns with a `GET` request with the following exceptions:
 
-| Name          | Type             | Required? | Nullable? | Description                                                                                                                             |
-| ------------- | ---------------- | --------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| language\_id  | ID               | yes       | no        | identifier of the [ language](#languages) to submit for                                                                                 |
-| problem\_id   | ID               | yes       | no        | identifier of the [ problem](#problems) to submit for                                                                                   |
-| team\_id      | ID               | yes       | no        | identifier of the [ team](#teams) that made the submission                                                                              |
-| time          | TIME             | no        | yes       | timestamp of when the submission was made                                                                                               |
-| entry\_point  | string           | no        | yes       | code entry point for specific languages                                                                                                 |
-| files         | array of ARCHIVE | yes       | no        | submission files, contained at the root of the archive. Only allowed mime type is application/zip. Only exactly one archive is allowed. |
+* Any provided `id`, `reaction` and `contest_time` attributes are ignored.
+* The `time` attribute is optional. If not provided (or `null`) it will default
+  to the current time as determined by the server.
+* Since `files` only supports `application/zip`, providing the `mime` field is
+  optional.
+* If the CCS supports a `team` role, the `team_id` and `time`
+  attributes will be ignored when using a this role. `team_id` will then use
+  the ID of the team associated with the request and `time` will always use
+  the current time as determined by the server.
 
 The response will be the ID of the newly added submission.
-
-The `time` attribute is optional. If not provided (or `null`) it will default
-to the current time as determined by the server.
-
-The `entry_point` attribute has the same requirements as for the `GET`
-requests, in that it is required for languages that do not have a single,
-unambiguous entry point to run the code.
-
-Since `files` only support application/zip, providing the `mime` field is
-optional. If the CCS supports a `team` role, the `team_id` and `time`
-attributes will be ignored when using a this role. `team_id` will then use
-the ID of the team associated with the request and `time` will always use
-the current time as determined by the server.
 
 The `public` role can never add submissions.
 

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -1047,9 +1047,7 @@ Java). For C and C++ no entry point is required and it must therefore be
 The `files` attribute provides the file(s) of a given submission as a
 zip archive. These must be stored directly from the root of the zip
 file, i.e. there must not be extra directories (or files) added unless
-these are explicitly part of the submission content. For `POST`,
-`PUT` and `PATCH` methods, the `files` attribute must contain the
-base64-encoded string of the zip archive.
+these are explicitly part of the submission content.
 
 #### Access restrictions at WF
 
@@ -1057,6 +1055,37 @@ The `entry_point` and `files` attribute are accessible only for
 clients with `admin` or `analyst` role. The `reaction` attribute
 is available to clients with `public` role only when the contest is
 not frozen.
+
+#### POST submissions
+
+To add submissions one can use the `POST` method on the submissions endpoint.
+The `POST` must include a valid JSON object with the following attributes:
+
+| Name          | Type             | Required? | Nullable? | Description                                                                                        |
+| ------------- | ---------------- | --------- | --------- | -------------------------------------------------------------------------------------------------- |
+| language\_id  | ID               | yes       | no        | identifier of the [ language](#languages) to submit for                                            |
+| problem\_id   | ID               | yes       | no        | identifier of the [ problem](#problems) to submit for                                              |
+| team\_id      | ID               | yes       | no        | identifier of the [ team](#teams) that made the submission                                         |
+| time          | TIME             | no        | yes       | timestamp of when the submission was made                                                          |
+| entry\_point  | string           | no        | yes       | code entry point for specific languages                                                            |
+| files         | array of ARCHIVE | yes       | no        | submission files, contained at the root of the archive. Only allowed mime type is application/zip. |
+
+The response will be the ID of the newly added submission.
+
+The `time` attribute is optional. If not provided (or `null`) it will default
+to the current time as determined by the server.
+
+The `entry_point` attribute has the same requirements as for the `GET`
+requests, in that it is required for languages that do not have a single,
+unambiguous entry point to run the code.
+
+Since `files` only support application/zip, providing the `mime` field is
+optional. If the CCS supports a `team` role, the `team_id` and `time`
+attributes will be ignored when using a this role. `team_id` will then use
+the ID of the team associated with the request and `time` will always use
+the current time as determined by the server.
+
+The `public` role can never add submissions.
 
 #### Example
 
@@ -1076,6 +1105,30 @@ Returned data:
 Note that the relative link for `files` points to the location
 <https://example.com/api/contests/wf14/submissions/187/files> since the
 base URL for the API is <https://example.com/api>.
+
+Request:
+
+` POST https://example.com/api/contests/wf14/submissions`
+
+Request data:
+
+```json
+{
+   "language_id": "1-java",
+   "problem_id": "10-asteroids",
+   "team_id": "123",
+   "time": "2014-06-25T11:22:05.034+01",
+   "entry_point": "Main",
+   "start_time": "2014-06-25T10:00:00+01",
+   "files": [{"data": "<base64 string>"}]
+}
+```
+
+Returned data:
+
+```json
+"187"
+```
 
 ### Judgements
 

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -1062,15 +1062,25 @@ To add submissions one can use the `POST` method on the submissions endpoint.
 The `POST` must include a valid JSON object with the same attributes the submission
 endpoint returns with a `GET` request with the following exceptions:
 
-* `id`, `reaction` and `contest_time` should not be provided, and are ignored.
+* `reaction` and `contest_time` should not be provided, and are ignored.
 * The `time` attribute is optional. If not provided (or `null`) it will default
   to the current time as determined by the server.
 * Since `files` only supports `application/zip`, providing the `mime` field is
   optional.
-* If the CCS supports a `team` role, the `team_id` and `time`
+* If the CCS supports a `team` role, the `team_id`, `time` and `id`
   attributes will be ignored when using this role. `team_id` will then be set to
   the ID of the team associated with the request and `time` will always use
-  the current time as determined by the server.
+  the current time as determined by the server. The CCS will determine an `id`.
+* If an `id` is supplied, the client should make sure it is unique, i.e. not used
+  yet on the CCS.
+
+The request should fail with a 400 if any of the following happens:
+
+* A required attribute is msising.
+* The supplied problem, team or language can not be found.
+* An entrypoint is required for the given language, but not supplied.
+* Something is wrong with the submission file. For example it contains too many
+  files, it is too big, etc.
 
 The response will be the ID of the newly added submission.
 

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -1062,15 +1062,16 @@ To add submissions one can use the `POST` method on the submissions endpoint.
 The `POST` must include a valid JSON object with the same attributes the submission
 endpoint returns with a `GET` request with the following exceptions:
 
-* `reaction` and `contest_time` should not be provided, and are ignored.
-* The `time` attribute is optional. If not provided (or `null`) it will default
-  to the current time as determined by the server.
 * Since `files` only supports `application/zip`, providing the `mime` field is
   optional.
-* If the CCS supports a `team` role, the `team_id`, `time` and `id`
-  attributes will be ignored when using this role. `team_id` will then be set to
-  the ID of the team associated with the request and `time` will always use
-  the current time as determined by the server. The CCS will determine an `id`.
+* `contest_time` must not be provided.
+* `reaction` may be provided but a CCS does not have to honour it.
+* The `time` attribute is optional. If not provided (or `null`) it will default
+  to the current time as determined by the server.
+* If the CCS supports a `team` role, `time` and `id`
+  must not be provided when using this role. `team_id` may be provided but then
+  must match the ID of the team associated with the request. `time` will then always
+  use the current time as determined by the server. The CCS will determine an `id`.
 * If an `id` is supplied, the client should make sure it is unique, i.e. not used
   yet on the CCS. The client should normally not supply `id`, but let it be determined
   by the server. However, for example in a setup with a central CCS with satellite sites
@@ -1082,6 +1083,7 @@ endpoint returns with a `GET` request with the following exceptions:
 The request should fail with a 400 if any of the following happens:
 
 * A required attribute is missing.
+* An attribute that must not be provided is provided.
 * The supplied problem, team or language can not be found.
 * An entrypoint is required for the given language, but not supplied.
 * Something is wrong with the submission file. For example it contains too many

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -1022,17 +1022,17 @@ The following endpoints are associated with submissions:
 
 JSON elements of submission objects:
 
-| Name          | Type             | Required? | Nullable? | Source @WF | Description                                                                                        |
-| ------------- | ---------------- | --------- | --------- | ---------- | -------------------------------------------------------------------------------------------------- |
-| id            | ID               | yes       | no        | CCS        | identifier of the submission. Usable as a label, typically a low incrementing number               |
-| language\_id  | ID               | yes       | no        | CCS        | identifier of the [ language](#languages) submitted for                                 |
-| problem\_id   | ID               | yes       | no        | CCS        | identifier of the [ problem](#problems) submitted for                                   |
-| team\_id      | ID               | yes       | no        | CCS        | identifier of the [ team](#teams) that made the submission                              |
-| time          | TIME             | yes       | no        | CCS        | timestamp of when the submission was made                                                          |
-| contest\_time | RELTIME          | yes       | no        | CCS        | contest relative time when the submission was made                                                 |
-| entry\_point  | string           | yes       | yes       | CCS        | code entry point for specific languages                                                            |
-| files         | array of ARCHIVE | yes       | no        | CCS        | submission files, contained at the root of the archive. Only allowed mime type is application/zip. |
-| reaction      | array of VIDEO   | no        | yes       | CDS        | reaction video from team's webcam.                                                                 |
+| Name          | Type             | Required? | Nullable? | Source @WF | Description                                                                                                                             |
+| ------------- | ---------------- | --------- | --------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| id            | ID               | yes       | no        | CCS        | identifier of the submission. Usable as a label, typically a low incrementing number                                                    |
+| language\_id  | ID               | yes       | no        | CCS        | identifier of the [ language](#languages) submitted for                                                                                 |
+| problem\_id   | ID               | yes       | no        | CCS        | identifier of the [ problem](#problems) submitted for                                                                                   |
+| team\_id      | ID               | yes       | no        | CCS        | identifier of the [ team](#teams) that made the submission                                                                              |
+| time          | TIME             | yes       | no        | CCS        | timestamp of when the submission was made                                                                                               |
+| contest\_time | RELTIME          | yes       | no        | CCS        | contest relative time when the submission was made                                                                                      |
+| entry\_point  | string           | yes       | yes       | CCS        | code entry point for specific languages                                                                                                 |
+| files         | array of ARCHIVE | yes       | no        | CCS        | submission files, contained at the root of the archive. Only allowed mime type is application/zip. Only exactly one archive is allowed. |
+| reaction      | array of VIDEO   | no        | yes       | CDS        | reaction video from team's webcam.                                                                                                      |
 
 The `entry_point` attribute must be included for submissions in
 languages which do not have a single, unambiguous entry point to run the
@@ -1061,14 +1061,14 @@ not frozen.
 To add submissions one can use the `POST` method on the submissions endpoint.
 The `POST` must include a valid JSON object with the following attributes:
 
-| Name          | Type             | Required? | Nullable? | Description                                                                                        |
-| ------------- | ---------------- | --------- | --------- | -------------------------------------------------------------------------------------------------- |
-| language\_id  | ID               | yes       | no        | identifier of the [ language](#languages) to submit for                                            |
-| problem\_id   | ID               | yes       | no        | identifier of the [ problem](#problems) to submit for                                              |
-| team\_id      | ID               | yes       | no        | identifier of the [ team](#teams) that made the submission                                         |
-| time          | TIME             | no        | yes       | timestamp of when the submission was made                                                          |
-| entry\_point  | string           | no        | yes       | code entry point for specific languages                                                            |
-| files         | array of ARCHIVE | yes       | no        | submission files, contained at the root of the archive. Only allowed mime type is application/zip. |
+| Name          | Type             | Required? | Nullable? | Description                                                                                                                             |
+| ------------- | ---------------- | --------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| language\_id  | ID               | yes       | no        | identifier of the [ language](#languages) to submit for                                                                                 |
+| problem\_id   | ID               | yes       | no        | identifier of the [ problem](#problems) to submit for                                                                                   |
+| team\_id      | ID               | yes       | no        | identifier of the [ team](#teams) that made the submission                                                                              |
+| time          | TIME             | no        | yes       | timestamp of when the submission was made                                                                                               |
+| entry\_point  | string           | no        | yes       | code entry point for specific languages                                                                                                 |
+| files         | array of ARCHIVE | yes       | no        | submission files, contained at the root of the archive. Only allowed mime type is application/zip. Only exactly one archive is allowed. |
 
 The response will be the ID of the newly added submission.
 


### PR DESCRIPTION
As discussed during the last call, I made a first attempt at adding the `POST .../submissions` endpoint.