### PR TITLE
Add require_entry_point, entry_point_description and extensions to language

### DIFF
--- a/Contest_API.md
+++ b/Contest_API.md
@@ -619,10 +619,13 @@ The following endpoints are associated with languages:
 
 JSON elements of language objects:
 
-| Name | Type   | Required? | Nullable? | Source @WF | Description                                                           |
-| ---- | ------ | --------- | --------- | ---------- | --------------------------------------------------------------------- |
-| id   | ID     | yes       | no        | CCS        | identifier of the language from table below                           |
-| name | string | yes       | no        | CCS        | name of the language (might not match table below, e.g. if localized) |
+| Name                    | Type            | Required? | Nullable? | Source @WF | Description                                                           |
+| ----------------------- | --------------- | --------- | --------- | ---------- | --------------------------------------------------------------------- |
+| id                      | ID              | yes       | no        | CCS        | identifier of the language from table below                           |
+| name                    | string          | yes       | no        | CCS        | name of the language (might not match table below, e.g. if localized) |
+| require_entry_point     | boolean         | yes       | no        | CCS        | if the language requires an entry point                               |
+| entry_point_description | string          | yes       | yes       | CCS        | if entry point is required, the description of the entry point        |
+| extensions              | array of string | yes       | no        | CCS        | file extensions for the language                                      |
 
 #### Access restrictions at WF
 
@@ -639,26 +642,26 @@ identifiers. It is recommended to choose new identifiers with a suffix
 appended to an existing one. For example `cpp17` to specify the ISO 2017
 version of C++.
 
-| ID         | Name        |
-| ---------- | ----------- |
-| ada        | Ada         |
-| c          | C           |
-| cpp        | C++         |
-| csharp     | C\#         |
-| go         | Go          |
-| haskell    | Haskell     |
-| java       | Java        |
-| javascript | JavaScript  |
-| kotlin     | Kotlin      |
-| objectivec | Objective-C |
-| pascal     | Pascal      |
-| php        | PHP         |
-| prolog     | Prolog      |
-| python2    | Python 2    |
-| python3    | Python 3    |
-| ruby       | Ruby        |
-| rust       | Rust        |
-| scala      | Scala       |
+| ID         | Name        | Extensions           |
+| ---------- | ----------- | -------------------- |
+| ada        | Ada         | adb, ads             |
+| c          | C           | c                    |
+| cpp        | C++         | cc, cpp, cxx, c++, C |
+| csharp     | C\#         | cs                   |
+| go         | Go          | go                   |
+| haskell    | Haskell     | hs                   |
+| java       | Java        | java                 |
+| javascript | JavaScript  | js                   |
+| kotlin     | Kotlin      | kt                   |
+| objectivec | Objective-C | m                    |
+| pascal     | Pascal      | pas                  |
+| php        | PHP         | php                  |
+| prolog     | Prolog      | pl                   |
+| python2    | Python 2    | py                   |
+| python3    | Python 3    | py                   |
+| ruby       | Ruby        | rb                   |
+| rust       | Rust        | rs                   |
+| scala      | Scala       | scala                |
 
 #### Example
 
@@ -671,13 +674,22 @@ Returned data:
 ```json
 [{
    "id": "java",
-   "name": "Java"
+   "name": "Java",
+   "require_entry_point": true,
+   "entry_point_description": "Main class",
+   "extensions": ["java"]
 }, {
    "id": "cpp",
-   "name": "GNU C++"
+   "name": "GNU C++",
+   "require_entry_point": false,
+   "entry_point_description": null,
+   "extensions": ["cc", "cpp", "cxx", "c++", "C"]
 }, {
-   "id": "python2",
-   "name": "Python 2"
+   "id": "python3",
+   "name": "Python 3",
+   "require_entry_point": false,
+   "entry_point_description": null,
+   "extensions": ["py"]
 }]
 ```
 

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -619,13 +619,13 @@ The following endpoints are associated with languages:
 
 JSON elements of language objects:
 
-| Name                    | Type            | Required? | Nullable? | Source @WF | Description                                                           |
-| ----------------------- | --------------- | --------- | --------- | ---------- | --------------------------------------------------------------------- |
-| id                      | ID              | yes       | no        | CCS        | identifier of the language from table below                           |
-| name                    | string          | yes       | no        | CCS        | name of the language (might not match table below, e.g. if localized) |
-| require_entry_point     | boolean         | yes       | no        | CCS        | if the language requires an entry point                               |
-| entry_point_description | string          | yes       | yes       | CCS        | if entry point is required, the description of the entry point        |
-| extensions              | array of string | yes       | no        | CCS        | file extensions for the language                                      |
+| Name                 | Type            | Required? | Nullable? | Source @WF | Description                                                                                                             |
+| -------------------- | --------------- | --------- | --------- | ---------- | ----------------------------------------------------------------------------------------------------------------------- |
+| id                   | ID              | yes       | no        | CCS        | identifier of the language from table below                                                                             |
+| name                 | string          | yes       | no        | CCS        | name of the language (might not match table below, e.g. if localized)                                                   |
+| entry_point_required | boolean         | yes       | no        | CCS        | whether the language requires an entry point                                                                            |
+| entry_point_name     | string          | depends   | yes       | CCS        | the name of the type of entry point, such as "Main class" or "Main file"). Required iff entry_point_required is present |
+| extensions           | array of string | yes       | no        | CCS        | file extensions for the language                                                                                        |
 
 #### Access restrictions at WF
 
@@ -633,35 +633,36 @@ No access restrictions apply to a GET on this endpoint.
 
 #### Known languages
 
-Below is a list of standardized identifiers for known languages. When
-providing one of these languages, the corresponding identifier should be
-used. The language name may be adapted e.g. for localization or to
+Below is a list of standardized identifiers for known languages with their
+name, extensions and entry point name (if any). When providing one of these
+languages, the corresponding identifier should be used. The language name
+and entry point name may be adapted e.g. for localization or to
 indicate a particular version of the language. In case multiple versions
 of a language are provided, those must have separate, unique
 identifiers. It is recommended to choose new identifiers with a suffix
 appended to an existing one. For example `cpp17` to specify the ISO 2017
 version of C++.
 
-| ID         | Name        | Extensions           |
-| ---------- | ----------- | -------------------- |
-| ada        | Ada         | adb, ads             |
-| c          | C           | c                    |
-| cpp        | C++         | cc, cpp, cxx, c++, C |
-| csharp     | C\#         | cs                   |
-| go         | Go          | go                   |
-| haskell    | Haskell     | hs                   |
-| java       | Java        | java                 |
-| javascript | JavaScript  | js                   |
-| kotlin     | Kotlin      | kt                   |
-| objectivec | Objective-C | m                    |
-| pascal     | Pascal      | pas                  |
-| php        | PHP         | php                  |
-| prolog     | Prolog      | pl                   |
-| python2    | Python 2    | py                   |
-| python3    | Python 3    | py                   |
-| ruby       | Ruby        | rb                   |
-| rust       | Rust        | rs                   |
-| scala      | Scala       | scala                |
+| ID         | Name        | Extensions           | Entry point name |
+| ---------- | ----------- | -------------------- | ---------------- |
+| ada        | Ada         | adb, ads             |                  |
+| c          | C           | c                    |                  |
+| cpp        | C++         | cc, cpp, cxx, c++, C |                  |
+| csharp     | C\#         | cs                   |                  |
+| go         | Go          | go                   |                  |
+| haskell    | Haskell     | hs                   |                  |
+| java       | Java        | java                 | Main class       |
+| javascript | JavaScript  | js                   | Main file        |
+| kotlin     | Kotlin      | kt                   | Main class       |
+| objectivec | Objective-C | m                    |                  |
+| pascal     | Pascal      | pas                  |                  |
+| php        | PHP         | php                  | Main file        |
+| prolog     | Prolog      | pl                   |                  |
+| python2    | Python 2    | py                   | Main file        |
+| python3    | Python 3    | py                   | Main file        |
+| ruby       | Ruby        | rb                   |                  |
+| rust       | Rust        | rs                   |                  |
+| scala      | Scala       | scala                |                  |
 
 #### Example
 
@@ -675,20 +676,19 @@ Returned data:
 [{
    "id": "java",
    "name": "Java",
-   "require_entry_point": true,
-   "entry_point_description": "Main class",
+   "entry_point_required": true,
+   "entry_point_name": "Main class",
    "extensions": ["java"]
 }, {
    "id": "cpp",
    "name": "GNU C++",
-   "require_entry_point": false,
-   "entry_point_description": null,
+   "entry_point_required": false,
    "extensions": ["cc", "cpp", "cxx", "c++", "C"]
 }, {
    "id": "python3",
    "name": "Python 3",
-   "require_entry_point": false,
-   "entry_point_description": null,
+   "entry_point_required": true,
+   "entry_point_name": "Main file",
    "extensions": ["py"]
 }]
 ```


### PR DESCRIPTION
I also updated the example to python3 since we live in 2021 🙈 .
Some discussion points:
* Should we make `entry_point_description` required no? But then since it is also nullable you don't know if the CCS supports it or has no value.
* Should we make it such that `entry_point_description` is required if `require_entry_point` is `true` and is null if `require_entry_point` is `false`? How do we word this?
* Do we want to add the list of extensions to the known language table like I did? We also have this list in the [problem package format](https://icpc.io/problem-package-format/spec/problem_package_format#programs) but might be good to list it here?
* I have explicitly not added a column for `require_entry_point` to the known languages table since that is quite WF specific; for example DOMjudge has a mode where we detect the main entrypoint serverside for Java / Kotlin, so then it would not be required. We just don't use it at WF.