### PR TITLE
Move changes from CAF into Contest API

### DIFF
--- a/Contest_API.md
+++ b/Contest_API.md
@@ -739,7 +739,7 @@ JSON elements of problem objects:
 | Name              | Type    | Required? | Nullable? | Source @WF | Description                                                                                                                                                       |
 | ----------------- | ------- | --------- | --------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | id                | ID      | yes       | no        | CCS        | identifier of the problem, at the WFs the directory name of the problem archive                                                                                   |
-| uuid              | string  | no        | yes       | not used   | UUID of the problem, as defiend in the problem package. |
+| uuid              | string  | no        | yes       | not used   | UUID of the problem, as defined in the problem package. |
 | label             | string  | yes       | no        | CCS        | label of the problem on the scoreboard, typically a single capitalized letter                                                                                     |
 | name              | string  | yes       | no        | CCS        | name of the problem                                                                                                                                               |
 | ordinal           | ORDINAL | yes       | no        | CCS        | ordering of problems on the scoreboard                                                                                                                            |

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -640,6 +640,8 @@ JSON elements of Command objects:
 | version         | string | no       | Expected output from running the version-command.                                      |
 | version-command | string | no       | Command to run to get the version. Defaults to `<command> --version` if not specified. |
 
+The compiler and runner elements are intended for informational purposes. It is not expected that systems will synchronize compiler and runner settings via this interface.
+
 #### Access restrictions at WF
 
 No access restrictions apply to a GET on this endpoint.
@@ -737,7 +739,7 @@ JSON elements of problem objects:
 | Name              | Type    | Required? | Nullable? | Source @WF | Description                                                                                                                                                       |
 | ----------------- | ------- | --------- | --------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | id                | ID      | yes       | no        | CCS        | identifier of the problem, at the WFs the directory name of the problem archive                                                                                   |
-| uuid              | string  | no        | yes       | not used   | UUID of the problem. |
+| uuid              | string  | no        | yes       | not used   | UUID of the problem, as defiend in the problem package. |
 | label             | string  | yes       | no        | CCS        | label of the problem on the scoreboard, typically a single capitalized letter                                                                                     |
 | name              | string  | yes       | no        | CCS        | name of the problem                                                                                                                                               |
 | ordinal           | ORDINAL | yes       | no        | CCS        | ordering of problems on the scoreboard                                                                                                                            |

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -628,6 +628,17 @@ JSON elements of language objects:
 | entry_point_required | boolean         | yes       | no        | CCS        | whether the language requires an entry point                                                                            |
 | entry_point_name     | string          | depends   | yes       | CCS        | the name of the type of entry point, such as "Main class" or "Main file"). Required iff entry_point_required is present |
 | extensions           | array of string | yes       | no        | CCS        | file extensions for the language                                                                                        |
+| compiler             | Command object  | no        | yes       | CCS        | Command used for compiling submissions.                                                                                 |
+| runner               | Command object  | no        | yes       | CCS        | Command used for running submissions. Relevant e.g. for interpreted languages and languages running on a VM.            |
+
+JSON elements of Command objects:
+
+| Name            | Type   | Required | Description |
+| :-------------- | :----- | :------- | :---------- |
+| command         | string | yes      | Command to run.                                                                        |
+| args            | string | no       | Argument list for command. {files} denotes where to include the file list.             |
+| version         | string | no       | Expected output from running the version-command.                                      |
+| version-command | string | no       | Command to run to get the version. Defaults to `<command> --version` if not specified. |
 
 #### Access restrictions at WF
 
@@ -680,12 +691,27 @@ Returned data:
    "name": "Java",
    "entry_point_required": true,
    "entry_point_name": "Main class",
-   "extensions": ["java"]
+   "extensions": ["java"],
+   "compiler": {
+      "command": "javac",
+      "args": "-O {files}",
+      "version": "javac 11.0.4",
+      "version-command": "javac --version"
+   },
+   "runner": {
+      "command": "java",
+      "version": "openjdk version \"11.0.4\" 2019-07-16"
+   }
 }, {
    "id": "cpp",
    "name": "GNU C++",
    "entry_point_required": false,
-   "extensions": ["cc", "cpp", "cxx", "c++", "C"]
+   "extensions": ["cc", "cpp", "cxx", "c++", "C"],
+   "compiler": {
+      "command": "gcc",
+      "args": "-O2 -Wall -o a.out -static {files}",
+      "version": "gcc (Ubuntu 8.3.0-6ubuntu1) 8.3.0"
+  }
 }, {
    "id": "python3",
    "name": "Python 3",
@@ -711,6 +737,7 @@ JSON elements of problem objects:
 | Name              | Type    | Required? | Nullable? | Source @WF | Description                                                                                                                                                       |
 | ----------------- | ------- | --------- | --------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | id                | ID      | yes       | no        | CCS        | identifier of the problem, at the WFs the directory name of the problem archive                                                                                   |
+| uuid              | string  | no        | yes       | not used   | UUID of the problem. |
 | label             | string  | yes       | no        | CCS        | label of the problem on the scoreboard, typically a single capitalized letter                                                                                     |
 | name              | string  | yes       | no        | CCS        | name of the problem                                                                                                                                               |
 | ordinal           | ORDINAL | yes       | no        | CCS        | ordering of problems on the scoreboard                                                                                                                            |

--- a/Contest_Archive_Format.md
+++ b/Contest_Archive_Format.md
@@ -116,7 +116,7 @@ The following JSON types are used.
 
 #### Differences from Contest API
 
-- The `countdown_pause_time` is not included. It is allowed buy the information should be ignored.
+- The `countdown_pause_time` is not included. It is allowed but the information should be ignored.
 - The `banner` and `logo` elements are not included. They are allowed but the information may be ignored. These files are instead found as `banner[.<size>].<format>` and `logo[.<size>].<format>` in the same directory as the JSON file.
 
 #### Examples

--- a/Contest_Archive_Format.md
+++ b/Contest_Archive_Format.md
@@ -116,7 +116,7 @@ The following JSON types are used.
 
 #### Differences from Contest API
 
-- The `countdown_pause_time` is not included.
+- The `countdown_pause_time` is not included. It is allowed buy the information should be ignored.
 - The `banner` and `logo` elements are not included. They are allowed but the information may be ignored. These files are instead found as `banner[.<size>].<format>` and `logo[.<size>].<format>` in the same directory as the JSON file.
 
 #### Examples
@@ -168,7 +168,7 @@ None.
 
 #### Differences from Contest API
 
-- Includes `compiler` and `runner` that contains the commands to use for compiling and running respectively. 
+None.
 
 #### Examples
 
@@ -254,7 +254,6 @@ None.
 
 - The `time_limit` element is required to be a `number` that is an
   integer multiple of `0.001` in the Contest API. 
-- The `uuid` element is not defined in the Contest API.
 
 #### Examples
 


### PR DESCRIPTION
Include the changes done in the Contest Archive Format into the API. This removed most differences. Remaining are:

- Binary file references are not required to work when saved to disk, rather binary files are stored in a predetermined location.
- `countdown_pause_time` is not in the CAF.
- Wherever `decimal` is used in the API, the CAF uses `number`, which is a built-in.
- CAF has not been updated for webhooks (but technically, neither has the API at the time of writing this).

We probably want to fix the last two...? 