### PR TITLE
Fix merge error and general clean-up

### DIFF
--- a/Contest_API.md
+++ b/Contest_API.md
@@ -621,44 +621,31 @@ Languages that are available for submission at the contest.
 
 The following endpoints are associated with languages:
 
-| Endpoint                        | Mime-type        | Required? | Source @WF | Description                                                                  |
-| ------------------------------- | ---------------- | --------- | ---------- | ---------------------------------------------------------------------------- |
-| `/contests/<id>/languages`      | application/json | yes       | CCS        | JSON array of all languages with elements as defined in the table below      |
-| `/contests/<id>/languages/<id>` | application/json | yes       | CCS        | JSON object of a single language with elements as defined in the table below |
+| Endpoint                        | Mime-type        | Required? | Source @WF | Description
+| :------------------------------ | :--------------- | :-------- | :--------- | :----------
+| `/contests/<id>/languages`      | application/json | yes       | CCS        | JSON array of all languages with elements as defined in the table below.
+| `/contests/<id>/languages/<id>` | application/json | yes       | CCS        | JSON object of a single language with elements as defined in the table below.
 
 JSON elements of language objects:
 
-| Name                 | Type   | Required? | Nullable? | Source @WF | Description                                                           |
-| -------------------- | ------ | --------- | --------- | ---------- | --------------------------------------------------------------------- |
-| id                   | ID     | yes       | no        | CCS        | identifier of the language from table below                           |
-| name                 | string | yes       | no        | CCS        | name of the language (might not match table below, e.g. if localized) |
-| compiler             | Command object | no | yes      | CCS        | Command used for compiling submissions. |
-| runner               | Command object | no | yes      | CCS        | Command used for running submissions. Relevant e.g. for interpreted languages and languages running on a VM. |
-| entry_point_required | boolean         | yes       | no        | CCS        | whether the language requires an entry point                                                                            |
-| entry_point_name     | string          | depends   | yes       | CCS        | the name of the type of entry point, such as "Main class" or "Main file"). Required iff entry_point_required is present |
-| extensions           | array of string | yes       | no        | CCS        | file extensions for the language                                                                                        |
-| compiler             | Command object  | no        | yes       | CCS        | Command used for compiling submissions.                                                                                 |
-| runner               | Command object  | no        | yes       | CCS        | Command used for running submissions. Relevant e.g. for interpreted languages and languages running on a VM.            |
+| Name                 | Type            | Required? | Nullable? | Source @WF | Description
+| :------------------- | :-------------- | :-------- | :-------- | :--------- | :----------
+| id                   | ID              | yes       | no        | CCS        | Identifier of the language from table below.
+| name                 | string          | yes       | no        | CCS        | Name of the language (might not match table below, e.g. if localized).
+| entry_point_required | boolean         | yes       | no        | CCS        | Whether the language requires an entry point.
+| entry_point_name     | string          | depends   | yes       | CCS        | The name of the type of entry point, such as "Main class" or "Main file"). Required iff entry_point_required is present.
+| extensions           | array of string | yes       | no        | CCS        | File extensions for the language.
+| compiler             | Command object  | no        | yes       | CCS        | Command used for compiling submissions.
+| runner               | Command object  | no        | yes       | CCS        | Command used for running submissions. Relevant e.g. for interpreted languages and languages running on a VM.
 
 JSON elements of Command objects:
 
-| Name            | Type   | Required | Description |
-| :-------------- | :----- | :------- | :---------- |
-| command         | string | yes      | Command to run.                                                                        |
-| args            | string | no       | Argument list for command. {files} denotes where to include the file list.             |
-| version         | string | no       | Expected output from running the version-command.                                      |
-| version-command | string | no       | Command to run to get the version. Defaults to `<command> --version` if not specified. |
-
-The compiler and runner elements are intended for informational purposes. It is not expected that systems will synchronize compiler and runner settings via this interface.
-
-JSON elements of Command objects:
-
-| Name            | Type   | Required | Description |
-| :-------------- | :----- | :------- | :---------- |
-| command         | string | yes      | Command to run.                                              |
-| args            | string | no       | Argument list for command. `{files}` denotes where to include the file list. |
-| version         | string | no       | Expected output from running the version-command.            |
-| version-command | string | no       | Command to run to get the version. Defaults to `<command> --version` if not specified. |
+| Name            | Type   | Required | Description
+| :-------------- | :----- | :------- | :----------
+| command         | string | yes      | Command to run.
+| args            | string | no       | Argument list for command. `{files}` denotes where to include the file list.
+| version         | string | no       | Expected output from running the version-command.
+| version-command | string | no       | Command to run to get the version. Defaults to `<command> --version` if not specified.
 
 The compiler and runner elements are intended for informational purposes. It is not expected that systems will synchronize compiler and runner settings via this interface.
 
@@ -679,7 +666,7 @@ appended to an existing one. For example `cpp17` to specify the ISO 2017
 version of C++.
 
 | ID         | Name        | Extensions           | Entry point name |
-| ---------- | ----------- | -------------------- | ---------------- |
+| :--------- | :---------- | :------------------- | :--------------- |
 | ada        | Ada         | adb, ads             |                  |
 | c          | C           | c                    |                  |
 | cpp        | C++         | cc, cpp, cxx, c++, C |                  |
@@ -711,16 +698,6 @@ Returned data:
 [{
    "id": "java",
    "name": "Java",
-   "compiler": {
-      "command": "javac",
-      "args": "-O {files}",
-      "version": "javac 11.0.4",
-      "version-command": "javac --version"
-   },
-   "runner": {
-      "command": "java",
-      "version": "openjdk version \"11.0.4\" 2019-07-16"
-   },
    "entry_point_required": true,
    "entry_point_name": "Main class",
    "extensions": ["java"],
@@ -744,11 +721,6 @@ Returned data:
    },
    "entry_point_required": false,
    "extensions": ["cc", "cpp", "cxx", "c++", "C"],
-   "compiler": {
-      "command": "gcc",
-      "args": "-O2 -Wall -o a.out -static {files}",
-      "version": "gcc (Ubuntu 8.3.0-6ubuntu1) 8.3.0"
-  }
 }, {
    "id": "python3",
    "name": "Python 3",


### PR DESCRIPTION
It seems that we accidentally duplicated the `compiler` and `runner` in some merge conflict. Fixed that and cleaned up the markup a bit.