### PR TITLE
Deprecate results.tsv

### DIFF
--- a/Contest_API.md
+++ b/Contest_API.md
@@ -1433,17 +1433,21 @@ JSON elements of award objects:
     can see; the public role's winner may not change during the
     scoreboard freeze but an admin could see the true current winner.
 
+#### Known awards
+
 For some common award cases the following IDs should be used.
 
-| ID                        | Meaning during contest                                                                                                     | Meaning when contest is final     | Comment
-| :------------------------ | :------------------------------------------------------------------------------------------------------------------------- | :-------------------------------- | :------
-| winner                    | Current leader(s). Empty if no team has scored.                                                                            | Winner(s) of the contest          |
-| gold-medal                | Teams currently placed to receive a gold medal. Empty if no team has scored.                                               | Teams being awarded gold medals   |
-| silver-medal              | Teams currently placed to receive a silver medal. Empty if no team has scored.                                             | Teams being awarded silver medals |
-| bronze-medal              | Teams currently placed to receive a bronze medal, assuming no extra bronze are awarded. Empty if no team has scored.       | Teams being awarded bronze medals |
-| first-to-solve-\<id>      | The team(s), if any, that was first to solve problem \<id>. This implies that no unjudged submission made earlier remains. | Same.                             | Must never change once set, except if there are rejudgements.
-| group-winner-\<id>        | Current leader(s) in group \<id>. Empty if no team has scored.                                                             | Winner(s) of group \<id>          |
-| organization-winner-\<id> | Current leader(s) of organization \<id>. Empty if no team has scored.                                                      | Winner(s) of organization \<id>   | Not useful in contest with only one team per organization (e.g. the WF).
+| ID                        | Meaning during contest                                                                                                     | Meaning when contest is final      | Comment
+| :------------------------ | :------------------------------------------------------------------------------------------------------------------------- | :--------------------------------- | :------
+| winner                    | Current leader(s). Empty if no team has scored.                                                                            | Winner(s) of the contest.          |
+| gold-medal                | Teams currently placed to receive a gold medal. Empty if no team has scored.                                               | Teams being awarded gold medals.   |
+| silver-medal              | Teams currently placed to receive a silver medal. Empty if no team has scored.                                             | Teams being awarded silver medals. |
+| bronze-medal              | Teams currently placed to receive a bronze medal, assuming no extra bronze are awarded. Empty if no team has scored.       | Teams being awarded bronze medals. |
+| rank-\<rank>              | Teams currently placed to recieve rank \<rank>. Empty if no team has scored.                                               | Teams being awarded rank \<rank>.  | Only useful in contests where the final ranking awarded is different from the default ranking of the scoreboard. E.g. at the WF teams *not* getting medals are only ranked based on number of problems solved, and not total penalty time accrued nor time of last score improvement, and teams solving strictly fewer problems than the median team are not ranked at all.  
+| honorable-mention         | Teams currently placed to recieve an honorable mention.                                                                    | Teams being awarded an HM.         |
+| first-to-solve-\<id>      | The team(s), if any, that was first to solve problem \<id>. This implies that no unjudged submission made earlier remains. | Same.                              | Must never change once set, except if there are rejudgements.
+| group-winner-\<id>        | Current leader(s) in group \<id>. Empty if no team has scored.                                                             | Winner(s) of group \<id>.          |
+| organization-winner-\<id> | Current leader(s) of organization \<id>. Empty if no team has scored.                                                      | Winner(s) of organization \<id>.   | Not useful in contest with only one team per organization (e.g. the WF).
 
 #### POST, PATCH, and DELETE awards
 


### PR DESCRIPTION
To be able to deprecate results.tsv we must make sure that all information that is currently in `results.tsv` is available from `/scoreboard` and `/awards`. Thus we need to add the awards `rank-\<rank>` and `honorable-mention`.

As written the CCS must include all the awards in `/awards`, but this could easily be handled by a separate (and shared) tool, as long as the CCS implements POST to `/awards`. I don't think this will be an undue burden.
