### PR TITLE
Clean up and simplify event feed spec

### DIFF
--- a/Contest_API.md
+++ b/Contest_API.md
@@ -1973,7 +1973,7 @@ The following are examples of contest events:
 
 ### Webhooks
 
-Webhooks recieving change [notifications](#notification-format) (events)
+Webhooks receiving change [notifications](#notification-format) (events)
 of the data presented by the API.
 
 The following endpoints are associated with webhooks:


### PR DESCRIPTION
Clean up and simplify the updated even feed spec. Breaking the notification format and webhook parts into their own sections.

Note that this does *not* describe the next version (probably 2021-11?) but rather the "future" version. "Downgrading" to the event feed structure used in 2020-03 will come in a later follow up PR.
