### PR TITLE
Add full and email to team-member

### DIFF
--- a/2021-11-draft/Contest_API.md
+++ b/2021-11-draft/Contest_API.md
@@ -1104,8 +1104,8 @@ JSON elements of team member objects:
 | id          | ID             | yes       | no        | Identifier of the team-member.
 | icpc\_id    | string         | no        | yes       | External identifier from ICPC CMS.
 | team\_id    | ID             | yes       | no        | [Team](#teams) of this team member.
-| first\_name | string         | yes       | no        | First name of team member.
-| last\_name  | string         | yes       | no        | Last name of team member.
+| name        | string         | yes       | no        | Name of team member.
+| email       | string         | no        | yes       | Email of team member.
 | sex         | string         | no        | yes       | Either `male` or `female`, or possibly `null`.
 | role        | string         | yes       | no        | One of `contestant` or `coach`.
 | photo       | array of IMAGE | no        | yes       | Registration photo of the team member.
@@ -1119,8 +1119,8 @@ Request:
 Returned data:
 
 ```json
-[{"id":"john-smith","team_id":"43","icpc_id":"32442","first_name":"John","last_name":"Smith","sex":"male","role":"contestant"},
- {"id":"osten-umlautsen","team_id":"43","icpc_id":null,"first_name":"Östen","last_name":"Ümlautsen","sex":null,"role":"coach"}
+[{"id":"john-smith","team_id":"43","icpc_id":"32442","name":"John Smith","email":"john.smith@kmail.com","sex":"male","role":"contestant"},
+ {"id":"osten-umlautsen","team_id":"43","icpc_id":null,"name":"Östen Ümlautsen","sex":null,"role":"coach"}
 ]
 ```
 

--- a/2021-11-draft/Contest_Archive_Format.md
+++ b/2021-11-draft/Contest_Archive_Format.md
@@ -444,8 +444,8 @@ None.
 | id         | ID     | yes      | Identifier of the team-member. |
 | icpc_id    | string | no       | External identifier from ICPC CMS. |
 | team_id    | ID     | yes      | Team of this team member. |
-| first_name | string | yes      | First name of team member. |
-| last_name  | string | yes      | Last name of team member. |
+| name       | string | yes      | Name of team member. |
+| email      | string | no       | Email of team member. |
 | sex        | string | no       | Either `male` or `female`, or possibly `null`. |
 | role       | string | yes      | One of `contestant` or `coach`. |
 
@@ -462,8 +462,8 @@ None.
   "id": "john-smith",
   "icpc_id": "32442",
   "team_id": "43",
-  "first_name": "John",
-  "last_name": "Smith",
+  "name": "John Smith",
+  "email": "john.smith@kmail.com",
   "sex": "male",
   "role": "contestant"
 }
@@ -473,8 +473,7 @@ None.
  {
   "id":"osten-umlautsen",
   "team_id": "43",
-  "first_name": "Östen",
-  "last_name": "Ümlautsen",
+  "name": "Östen Ümlautsen",
   "sex": null,
   "role": "coach"
 }

--- a/draft/Contest_API.md
+++ b/draft/Contest_API.md
@@ -1101,8 +1101,8 @@ JSON elements of team member objects:
 | id          | ID             | yes       | no        | Identifier of the team-member.
 | icpc\_id    | string         | no        | yes       | External identifier from ICPC CMS.
 | team\_id    | ID             | yes       | no        | [Team](#teams) of this team member.
-| first\_name | string         | yes       | no        | First name of team member.
-| last\_name  | string         | yes       | no        | Last name of team member.
+| name        | string         | yes       | no        | Name of team member.
+| email       | string         | no        | yes       | Email of team member.
 | sex         | string         | no        | yes       | Either `male` or `female`, or possibly `null`.
 | role        | string         | yes       | no        | One of `contestant` or `coach`.
 | photo       | array of IMAGE | no        | yes       | Registration photo of the team member.
@@ -1116,8 +1116,8 @@ Request:
 Returned data:
 
 ```json
-[{"id":"john-smith","team_id":"43","icpc_id":"32442","first_name":"John","last_name":"Smith","sex":"male","role":"contestant"},
- {"id":"osten-umlautsen","team_id":"43","icpc_id":null,"first_name":"Östen","last_name":"Ümlautsen","sex":null,"role":"coach"}
+[{"id":"john-smith","team_id":"43","icpc_id":"32442","name":"John Smith","email":"john.smith@kmail.com","sex":"male","role":"contestant"},
+ {"id":"osten-umlautsen","team_id":"43","icpc_id":null,"name":"Östen Ümlautsen","sex":null,"role":"coach"}
 ]
 ```
 

--- a/draft/Contest_Archive_Format.md
+++ b/draft/Contest_Archive_Format.md
@@ -444,8 +444,8 @@ None.
 | id         | ID     | yes      | Identifier of the team-member. |
 | icpc_id    | string | no       | External identifier from ICPC CMS. |
 | team_id    | ID     | yes      | Team of this team member. |
-| first_name | string | yes      | First name of team member. |
-| last_name  | string | yes      | Last name of team member. |
+| name       | string | yes      | Name of team member. |
+| email      | string | no       | Email of team member. |
 | sex        | string | no       | Either `male` or `female`, or possibly `null`. |
 | role       | string | yes      | One of `contestant` or `coach`. |
 
@@ -462,8 +462,8 @@ None.
   "id": "john-smith",
   "icpc_id": "32442",
   "team_id": "43",
-  "first_name": "John",
-  "last_name": "Smith",
+  "name": "John Smith",
+  "email": "john.smith@kmail.com",
   "sex": "male",
   "role": "contestant"
 }
@@ -473,8 +473,7 @@ None.
  {
   "id":"osten-umlautsen",
   "team_id": "43",
-  "first_name": "Östen",
-  "last_name": "Ümlautsen",
+  "name": "Östen Ümlautsen",
   "sex": null,
   "role": "coach"
 }


### PR DESCRIPTION
Adding (full) `name` and `email` to team-member, and removing `first_name` and `last_name`.

Names of contestants are not always available split up as first and last name (and it's not always possible to make that split). I.e. if you have `name` you can't always get `first_name` and `last_name`, but if you have `first_name` and `last_name` you can easily get `name`.

The emails of contestants are (typically) needed for online contest setups, and are (typically) available in the registration data. This is more aimed at the CAF than the actual API, but they are kinda the same thing, so...

This change is made to both `2021-11-draft` and `draft`.