### PR TITLE
Drop top directories from CAF

### DIFF
--- a/2021-11-draft/Contest_Archive_Format.md
+++ b/2021-11-draft/Contest_Archive_Format.md
@@ -22,20 +22,22 @@ level structure is inspired by the [Contest API](contest_api) structure.
 
 ## Archive contents
 
-There are four top level directories:
-
-* `config` - configuration and setup
-* `registration` - information about participants
-* `events` - detailed information about what happened during the contest
-* `results` - end results (this is typically an aggregate of the events)
+The package consists of a single directory containing files as described
+below, or alternatively, a ZIP compressed archive of the same files. It is
+strongly recommended that the name of the directory or the base name of the
+archive match the contest ID, if a contest ID is specified. 
 
 All JSON and NDJSON files and file directories map to endpoints of the
 [Contest API](contest_api) in the following way.
 
-The format of the JSON returned from `<endpoint>` is accepted as the
-contents of `<endpoint>`.json (or .ndjson in the case of
-`event-feed.ndjson`). Some fields that are required in the contest API
-are optional in this file format, to support some non-contest use cases.
+The format of the JSON returned from `<endpoint>` is accepted as the contents
+of `<endpoint>.json` (or `.ndjson` in the case of `event-feed.ndjson`). For
+some files it could make sense to store multiple versions of the file. If so
+the alternate versions must be stored as `<endpoint>.<version>.[nd]json`. One
+example of this could be the judgements from a shadow CCS, which should be
+stored as `judgement.shadow.json`. Some fields that are required in the
+contest API are optional in this file format, to support some non-contest use
+cases.
 
 Also, all files referenced from the JSON of endpoints are stored in the
 `<endpoint>` directory. As such the file reference fields are not
@@ -51,29 +53,29 @@ API to be able to use this archive format.
 The problem package is not available from the contest API but is stored
 using a similar naming convention.
 
-| File name                             | Format | Description | Required |
-| :------------------------------------ | :----- | :---------- | :------- |
-| `config/contest.json`                 | JSON   | [Contest object](#contest-object). | No |
-| `config/contest`                      | Directory | [Contest files](#contest-files). | No |
-| `config/judgement-types.json`         | JSON   | Array of [judgement type objects](#judgement-type-object). | Yes |
-| `config/languages.json`               | JSON   | Array of [language objects](#language-object). | Yes |
-| `config/problems.json`                | JSON   | Array of [problem objects](#problem-object). | Yes |
-| `config/problems/<problem-ID>[.kpp]`  | [KPP](https://www.kattis.com/problem-package-format/) | [Problem package](#problem-package) | No |
-| `registration/groups.json`            | JSON   | Array of [group objects](#group-object). | No |
-| `registration/organizations.json`     | JSON   | Array of [organization objects](#organization-object). | No |
-| `registration/organizations/<organization-ID>` | Directory | [Organization files](#organization-files).| No |
-| `registration/teams.json`             | JSON   | Array of [team objects](#team-object). | Yes |
-| `registration/teams/<team-ID>`        | Directory | [Team files](#team-files). | No |
-| `registration/team-members.json`      | JSON   | Array of [team member objects](#team-member-object). | No |
-| `registration/team-members/<team-member-ID>` | Directory | [Team member files](#team-member-files). | No |
-| `events/submissions.json`             | JSON   | Array of [submission objects](#submission-object). | No |
-| `events/submissions/<submission-ID>`  | Directory | [Submission files](#submission-files). | No |
-| `events/judgements[.<system>].json`   | JSON   | Array of [judgement objects](#judgement-object). | No |
-| `events/runs[.<system>].json`         | JSON   | Array of [run objects](#run-object). | No |
-| `events/clarifications.json`          | JSON   | Array of [clarification objects](#clarification-object). | No |
-| `events/event-feed[.<system>].ndjson` | [NDJSON](http://ndjson.org/) | [Event feed objects](#event-feed-object). | No |
-| `results/awards.json`                 | JSON   | Array of [awards objects](#award-object). | No |
-| `results/scoreboard.json`             | JSON   | [Scoreboard object](#scoreboard-object). | No |
+| File path                              | Format | Description | Required |
+| :------------------------------------- | :----- | :---------- | :------- |
+| `<ID>/contest.json`                    | JSON   | [Contest object](#contest-object). | No |
+| `<ID>/contest`                         | Directory | [Contest files](#contest-files). | No |
+| `<ID>/judgement-types.json`            | JSON   | Array of [judgement type objects](#judgement-type-object). | Yes |
+| `<ID>/languages.json`                  | JSON   | Array of [language objects](#language-object). | Yes |
+| `<ID>/problems.json`                   | JSON   | Array of [problem objects](#problem-object). | Yes |
+| `<ID>/problems/<problem-ID>[.kpp]`     | [KPP](https://www.kattis.com/problem-package-format/) | [Problem package](#problem-package) | No |
+| `<ID>/groups.json`                     | JSON   | Array of [group objects](#group-object). | No |
+| `<ID>/organizations.json`              | JSON   | Array of [organization objects](#organization-object). | No |
+| `<ID>/organizations/<organization-ID>` | Directory | [Organization files](#organization-files).| No |
+| `<ID>/teams.json`                      | JSON   | Array of [team objects](#team-object). | Yes |
+| `<ID>/teams/<team-ID>`                 | Directory | [Team files](#team-files). | No |
+| `<ID>/team-members.json`               | JSON   | Array of [team member objects](#team-member-object). | No |
+| `<ID>/team-members/<team-member-ID>`   | Directory | [Team member files](#team-member-files). | No |
+| `<ID>/submissions.json`                | JSON   | Array of [submission objects](#submission-object). | No |
+| `<ID>/submissions/<submission-ID>`     | Directory | [Submission files](#submission-files). | No |
+| `<ID>/judgements[.<system>].json`      | JSON   | Array of [judgement objects](#judgement-object). | No |
+| `<ID>/runs[.<system>].json`            | JSON   | Array of [run objects](#run-object). | No |
+| `<ID>/clarifications.json`             | JSON   | Array of [clarification objects](#clarification-object). | No |
+| `<ID>/event-feed[.<system>].ndjson`    | [NDJSON](http://ndjson.org/) | [Event feed objects](#event-feed-object). | No |
+| `<ID>/awards.json`                     | JSON   | Array of [awards objects](#award-object). | No |
+| `<ID>/scoreboard.json`                 | JSON   | [Scoreboard object](#scoreboard-object). | No |
 
 ## JSON objects
 
@@ -117,7 +119,7 @@ The following JSON types are used.
 #### Differences from Contest API
 
 - The `countdown_pause_time` is not included. It is allowed but the information should be ignored.
-- The `banner` and `logo` elements are not included. They are allowed but the information may be ignored. These files are instead found as `banner[.<size>].<format>` and `logo[.<size>].<format>` in the same directory as the JSON file.
+- The `banner` and `logo` elements are not included. They are allowed but the information may be ignored. These files are instead found as `banner[.<size>].<format>` and `logo[.<size>].<format>` in the `contest` directory.
 
 #### Examples
 
@@ -327,9 +329,9 @@ None.
 
 #### Differences from Contest API
 
-- The `logo` element is not included. It is allowed but the information
-  may be ignored. These files are instead found as
-  `logo[.<size>].<format>` in the same directory as the JSON file.
+- The `logo` element is not included. It is allowed but the information may be
+  ignored. These files are instead found as `logo[.<size>].<format>` in the in
+  the `organizations/<organization-ID>` directory.
 
 #### Examples
 
@@ -451,9 +453,9 @@ None.
 
 #### Differences from Contest API
 
-- The `photo` element is not included. It is allowed but the information
-  may be ignored. These files are instead found as
-  `photo[.<size>].<format>` in the same directory as the JSON file.
+- The `photo` element is not included. It is allowed but the information may
+  be ignored. These files are instead found as `photo[.<size>].<format>` in
+  the `team-members/<team-member-ID>` directory.
 
 #### Examples
 
@@ -496,7 +498,7 @@ None.
 
 - The `files` and `reaction` elements are not included. They are allowed
   but the information may be ignored. These files are instead found in 
-  the same directory as the JSON file.
+  the `submissions/<submission-ID>` directory.
 
 #### Examples
 

--- a/draft/Contest_Archive_Format.md
+++ b/draft/Contest_Archive_Format.md
@@ -22,20 +22,22 @@ level structure is inspired by the [Contest API](contest_api) structure.
 
 ## Archive contents
 
-There are four top level directories:
-
-* `config` - configuration and setup
-* `registration` - information about participants
-* `events` - detailed information about what happened during the contest
-* `results` - end results (this is typically an aggregate of the events)
+The package consists of a single directory containing files as described
+below, or alternatively, a ZIP compressed archive of the same files. It is
+strongly recommended that the name of the directory or the base name of the
+archive match the contest ID, if a contest ID is specified. 
 
 All JSON and NDJSON files and file directories map to endpoints of the
 [Contest API](contest_api) in the following way.
 
-The format of the JSON returned from `<endpoint>` is accepted as the
-contents of `<endpoint>`.json (or .ndjson in the case of
-`event-feed.ndjson`). Some fields that are required in the contest API
-are optional in this file format, to support some non-contest use cases.
+The format of the JSON returned from `<endpoint>` is accepted as the contents
+of `<endpoint>.json` (or `.ndjson` in the case of `event-feed.ndjson`). For
+some files it could make sense to store multiple versions of the file. If so
+the alternate versions must be stored as `<endpoint>.<version>.[nd]json`. One
+example of this could be the judgements from a shadow CCS, which should be
+stored as `judgement.shadow.json`. Some fields that are required in the
+contest API are optional in this file format, to support some non-contest use
+cases.
 
 Also, all files referenced from the JSON of endpoints are stored in the
 `<endpoint>` directory. As such the file reference fields are not
@@ -51,29 +53,29 @@ API to be able to use this archive format.
 The problem package is not available from the contest API but is stored
 using a similar naming convention.
 
-| File name                             | Format | Description | Required |
-| :------------------------------------ | :----- | :---------- | :------- |
-| `config/contest.json`                 | JSON   | [Contest object](#contest-object). | No |
-| `config/contest`                      | Directory | [Contest files](#contest-files). | No |
-| `config/judgement-types.json`         | JSON   | Array of [judgement type objects](#judgement-type-object). | Yes |
-| `config/languages.json`               | JSON   | Array of [language objects](#language-object). | Yes |
-| `config/problems.json`                | JSON   | Array of [problem objects](#problem-object). | Yes |
-| `config/problems/<problem-ID>[.kpp]`  | [KPP](https://www.kattis.com/problem-package-format/) | [Problem package](#problem-package) | No |
-| `registration/groups.json`            | JSON   | Array of [group objects](#group-object). | No |
-| `registration/organizations.json`     | JSON   | Array of [organization objects](#organization-object). | No |
-| `registration/organizations/<organization-ID>` | Directory | [Organization files](#organization-files).| No |
-| `registration/teams.json`             | JSON   | Array of [team objects](#team-object). | Yes |
-| `registration/teams/<team-ID>`        | Directory | [Team files](#team-files). | No |
-| `registration/team-members.json`      | JSON   | Array of [team member objects](#team-member-object). | No |
-| `registration/team-members/<team-member-ID>` | Directory | [Team member files](#team-member-files). | No |
-| `events/submissions.json`             | JSON   | Array of [submission objects](#submission-object). | No |
-| `events/submissions/<submission-ID>`  | Directory | [Submission files](#submission-files). | No |
-| `events/judgements[.<system>].json`   | JSON   | Array of [judgement objects](#judgement-object). | No |
-| `events/runs[.<system>].json`         | JSON   | Array of [run objects](#run-object). | No |
-| `events/clarifications.json`          | JSON   | Array of [clarification objects](#clarification-object). | No |
-| `events/event-feed[.<system>].ndjson` | [NDJSON](http://ndjson.org/) | [Event feed objects](#event-feed-object). | No |
-| `results/awards.json`                 | JSON   | Array of [awards objects](#award-object). | No |
-| `results/scoreboard.json`             | JSON   | [Scoreboard object](#scoreboard-object). | No |
+| File path                              | Format | Description | Required |
+| :------------------------------------- | :----- | :---------- | :------- |
+| `<ID>/contest.json`                    | JSON   | [Contest object](#contest-object). | No |
+| `<ID>/contest`                         | Directory | [Contest files](#contest-files). | No |
+| `<ID>/judgement-types.json`            | JSON   | Array of [judgement type objects](#judgement-type-object). | Yes |
+| `<ID>/languages.json`                  | JSON   | Array of [language objects](#language-object). | Yes |
+| `<ID>/problems.json`                   | JSON   | Array of [problem objects](#problem-object). | Yes |
+| `<ID>/problems/<problem-ID>[.kpp]`     | [KPP](https://www.kattis.com/problem-package-format/) | [Problem package](#problem-package) | No |
+| `<ID>/groups.json`                     | JSON   | Array of [group objects](#group-object). | No |
+| `<ID>/organizations.json`              | JSON   | Array of [organization objects](#organization-object). | No |
+| `<ID>/organizations/<organization-ID>` | Directory | [Organization files](#organization-files).| No |
+| `<ID>/teams.json`                      | JSON   | Array of [team objects](#team-object). | Yes |
+| `<ID>/teams/<team-ID>`                 | Directory | [Team files](#team-files). | No |
+| `<ID>/team-members.json`               | JSON   | Array of [team member objects](#team-member-object). | No |
+| `<ID>/team-members/<team-member-ID>`   | Directory | [Team member files](#team-member-files). | No |
+| `<ID>/submissions.json`                | JSON   | Array of [submission objects](#submission-object). | No |
+| `<ID>/submissions/<submission-ID>`     | Directory | [Submission files](#submission-files). | No |
+| `<ID>/judgements[.<system>].json`      | JSON   | Array of [judgement objects](#judgement-object). | No |
+| `<ID>/runs[.<system>].json`            | JSON   | Array of [run objects](#run-object). | No |
+| `<ID>/clarifications.json`             | JSON   | Array of [clarification objects](#clarification-object). | No |
+| `<ID>/event-feed[.<system>].ndjson`    | [NDJSON](http://ndjson.org/) | [Event feed objects](#event-feed-object). | No |
+| `<ID>/awards.json`                     | JSON   | Array of [awards objects](#award-object). | No |
+| `<ID>/scoreboard.json`                 | JSON   | [Scoreboard object](#scoreboard-object). | No |
 
 ## JSON objects
 
@@ -117,7 +119,7 @@ The following JSON types are used.
 #### Differences from Contest API
 
 - The `countdown_pause_time` is not included. It is allowed but the information should be ignored.
-- The `banner` and `logo` elements are not included. They are allowed but the information may be ignored. These files are instead found as `banner[.<size>].<format>` and `logo[.<size>].<format>` in the same directory as the JSON file.
+- The `banner` and `logo` elements are not included. They are allowed but the information may be ignored. These files are instead found as `banner[.<size>].<format>` and `logo[.<size>].<format>` in the `contest` directory.
 
 #### Examples
 
@@ -327,9 +329,9 @@ None.
 
 #### Differences from Contest API
 
-- The `logo` element is not included. It is allowed but the information
-  may be ignored. These files are instead found as
-  `logo[.<size>].<format>` in the same directory as the JSON file.
+- The `logo` element is not included. It is allowed but the information may be
+  ignored. These files are instead found as `logo[.<size>].<format>` in the in
+  the `organizations/<organization-ID>` directory.
 
 #### Examples
 
@@ -451,9 +453,9 @@ None.
 
 #### Differences from Contest API
 
-- The `photo` element is not included. It is allowed but the information
-  may be ignored. These files are instead found as
-  `photo[.<size>].<format>` in the same directory as the JSON file.
+- The `photo` element is not included. It is allowed but the information may
+  be ignored. These files are instead found as `photo[.<size>].<format>` in
+  the `team-members/<team-member-ID>` directory.
 
 #### Examples
 
@@ -496,7 +498,7 @@ None.
 
 - The `files` and `reaction` elements are not included. They are allowed
   but the information may be ignored. These files are instead found in 
-  the same directory as the JSON file.
+  the `submissions/<submission-ID>` directory.
 
 #### Examples
 


### PR DESCRIPTION
Dropping the top directories from CAF.

Replaces #62.
