### PR TITLE
Make scoring contest results explicit for clients

### DIFF
--- a/draft/Contest_API.md
+++ b/draft/Contest_API.md
@@ -883,6 +883,7 @@ JSON elements of problem objects:
 | color             | string  | no        | no        | Human readable color description associated to the RGB value.
 | time\_limit       | number  | no        | no        | Time limit in seconds per test data set (i.e. per single run). Should be an integer multiple of `0.001`.
 | test\_data\_count | integer | yes       | no        | Number of test data sets.
+| max_score         | number  | no        | no        | Maximum expected score, although teams may score higher in some cases. Typically used to indicate scoreboard cell color in scoring contests. Required iff contest:scoreboard_type is `score`.
 
 #### Examples
 
@@ -1383,7 +1384,7 @@ JSON elements of judgement objects:
 | id                   | ID      | yes       | no        | Identifier of the judgement.
 | submission\_id       | ID      | yes       | no        | Identifier of the [ submission](#submissions) judged.
 | judgement\_type\_id  | ID      | yes       | yes       | The [ verdict](#judgement-types) of this judgement.
-| score                | number  | no        | no        | Score for this judgement. Only relevant if contest:scoreboard_type is `score`. Defaults to `100` if missing.
+| score                | number  | no        | no        | Score for this judgement. Required iff contest:scoreboard_type is `score`.
 | start\_time          | TIME    | yes       | no        | Absolute time when judgement started.
 | start\_contest\_time | RELTIME | yes       | no        | Contest relative time when judgement started.
 | end\_time            | TIME    | yes       | yes       | Absolute time when judgement completed.
@@ -1842,8 +1843,8 @@ Each problem object within the scoreboard consists of:
 | num\_judged  | integer | yes       | no        | Number of judged submissions (up to and including the first correct one),
 | num\_pending | integer | yes       | no        | Number of pending submissions (either queued or due to freeze).
 | solved       | boolean | depends   | yes       | Required iff contest:scoreboard_type is `pass-fail`.
-| score        | number  | depends   | no        | Required iff contest:scoreboard_type is `score` and solved is missing. If missing or `null` defaults to `100` if solved is `true` and `0` if solved is `false`.
-| time         | integer | depends   | no        | Minutes into the contest when this problem was solved by the team. Required iff `solved=true`.
+| score        | number  | depends   | no        | Required iff contest:scoreboard_type is `score`.
+| time         | integer | depends   | no        | Minutes into the contest when this problem was solved by the team. Required iff `solved=true` or `score>0`.
 
 #### Examples
 


### PR DESCRIPTION
Removed client-side requirement to understand default scores or calculating scores for scoring contests. Servers are still welcome to use 100 as the default, but clients don't need to know; scoreboard is simple and the max_score should provide enough info to color table cells.

The changes:
- Made the judgement score required so that clients don't need to understand the default.
- Made score required to simplify client-side interpretation.
- Added max_score to problems to help clients understand relative scores and colour scoreboard cells appropriately.