### PR TITLE
Update notification format & feed/webhook

### DIFF
--- a/Contest_API.md
+++ b/Contest_API.md
@@ -346,19 +346,16 @@ etc.) or entire collection. The general format for events is:
 
 | Name        | Type            | Required? | Nullable? | Description
 | :---------- | :-------------- | :-------- | :-------- | :----------
-| type        | string          | yes       | yes       | The type of contest object that changed. Can be used for filtering.
+| type        | string          | yes       | no        | The type of contest object that changed. Can be used for filtering.
 | id          | string          | yes       | yes       | The id of the object that changed, or null for the entire collection/singleton.
 | data        | array or object | yes       | yes       | The updated value, i.e. what would be returned if calling the corresponding API endpoint at this time: an array, object, or null for deletions.
 
 Each event is a notification that an object or a collection has changed
 (and hence the contents of the corresponding endpoint) to `data`.
 
-If `type` and `id` are both non-null, then the object at
-`/contests/<contest_id>/<type>/<id>` now has the contents of `data`.
-If `id` is null, then the entire collection at `/contests/<contest_id>/<type>`
-now has the contents of `data`. If both are null, then the contest at
-`/contests/<contest_id>` now has the contents of `data`.
-
+If `type` is `contest`, then the contest at `/contests/<id>` now has the contents of `data`.
+If `id` is not null, then the object at `/contests/<contest_id>/<type>/<id>` now has the contents of `data`.
+If `id` is null, then the entire collection at `/contests/<contest_id>/<type>` now has the contents of `data`.
 
 #### Examples
 

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -322,7 +322,7 @@ are meant to ease extensibility.
 ### Notification format
 
 There are two mechanisms that clients can use to receive notifications
-of API updates (events), a webhook and a streaming HTTP feed. Both
+of API updates (events): a webhook and a streaming HTTP feed. Both
 mechanisms use the same payload format, but have different benefits,
 drawbacks, and ways to access. Webhooks are typically better for
 internet-scale, asynchronous processing, and disconnected systems; the
@@ -338,7 +338,7 @@ for these, since there will always be another event sent.
 
 The events are served as JSON objects, with every event corresponding to
 a change in a single object (submission, judgement, language, team,
-etc.) or full endpoint. The general format for events is:
+etc.) or entire collection. The general format for events is:
 
 ```json
 {"type": "<type>", "id": "<id>", "data": <JSON data for element> }
@@ -348,11 +348,17 @@ etc.) or full endpoint. The general format for events is:
 | :---------- | :-------------- | :-------- | :-------- | :----------
 | type        | string          | yes       | yes       | The type of contest object that changed. Can be used for filtering.
 | id          | string          | yes       | yes       | The id of the object that changed, or null for the entire collection/singleton.
-| data        | array or object | yes       | yes       | The object that would be returned if calling the corresponding API endpoint at this time, i.e. an array, object, or null for deletions.
+| data        | array or object | yes       | yes       | The updated value, i.e. what would be returned if calling the corresponding API endpoint at this time: an array, object, or null for deletions.
 
+Each event is a notification that an object or a collection has changed
+(and hence the contents of the corresponding endpoint) to `data`.
 
-The meaning of an event is to say that the contents at endpoint
-`/contests/<contest_id>/<type>/<id>` (or `/contests/<contest_id>/<type>` `/contests/<contest_id>`) now has the contents of `data`.
+If `type` and `id` are both non-null, then the object at
+`/contests/<contest_id>/<type>/<id>` now has the contents of `data`.
+If `id` is null, then the entire collection at `/contests/<contest_id>/<type>`
+now has the contents of `data`. If both are null, then the contest at
+`/contests/<contest_id>` now has the contents of `data`.
+
 
 #### Examples
 

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -348,7 +348,7 @@ etc.) or full endpoint. The general format for events is:
 | :---------- | :----- | :-------- | :-------- | :----------
 | type        | string | yes       | yes       | The type of contest object that changed. Can be used for filtering.
 | id          | string | yes       | yes       | The id of the object that changed, or null for the entire collection/singleton.
-| data        | object | yes       | yes       | The object that would be returned if calling the corresponding API endpoint at this time, i.e. an object, or null for deletions.
+| data        | object | yes       | yes       | The object that would be returned if calling the corresponding API endpoint at this time, i.e. an array, object, or null for deletions.
 
 
 The meaning of an event is to say that the contents at endpoint

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -344,15 +344,15 @@ etc.) or full endpoint. The general format for events is:
 {"type": "<type>", "id": "<id>", "data": <JSON data for element> }
 ```
 
-| Name        | Type   | Required? | Nullable? | Description
-| :---------- | :----- | :-------- | :-------- | :----------
-| type        | string | yes       | yes       | The type of contest object that changed. Can be used for filtering.
-| id          | string | yes       | yes       | The id of the object that changed, or null for the entire collection/singleton.
-| data        | object | yes       | yes       | The object that would be returned if calling the corresponding API endpoint at this time, i.e. an array, object, or null for deletions.
+| Name        | Type            | Required? | Nullable? | Description
+| :---------- | :-------------- | :-------- | :-------- | :----------
+| type        | string          | yes       | yes       | The type of contest object that changed. Can be used for filtering.
+| id          | string          | yes       | yes       | The id of the object that changed, or null for the entire collection/singleton.
+| data        | array or object | yes       | yes       | The object that would be returned if calling the corresponding API endpoint at this time, i.e. an array, object, or null for deletions.
 
 
 The meaning of an event is to say that the contents at endpoint
-`/contests/<contest_id>/<type>/<id>` now has the contents of `data`.
+`/contests/<contest_id>/<type>/<id>` (or `/contests/<contest_id>/<type>` `/contests/<contest_id>`) now has the contents of `data`.
 
 #### Examples
 

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -350,10 +350,30 @@ etc.) or entire collection. The general format for events is:
 | id          | string          | yes       | yes       | The id of the object that changed, or null for the entire collection/singleton.
 | data        | array or object | yes       | yes       | The updated value, i.e. what would be returned if calling the corresponding API endpoint at this time: an array, object, or null for deletions.
 
+All event types correspond to an API endpoint, as specified in the table below.
+
+| Event           | API Endpoint                          |
+| :-------------- | :------------------------------------ |
+| contest         | `/contests/<id>`                      |
+| judgement-types | `/contests/<id>/judgement-types/<id>` |
+| languages       | `/contests/<id>/languages/<id>`       |
+| problems        | `/contests/<id>/problems/<id>`        |
+| groups          | `/contests/<id>/groups/<id>`          |
+| organizations   | `/contests/<id>/organizations/<id>`   |
+| teams           | `/contests/<id>/teams/<id>`           |
+| people          | `/contests/<id>/people/<id>`          |
+| accounts        | `/contests/<id>/accounts/<id>`        |
+| state           | `/contests/<id>/state`                |
+| submissions     | `/contests/<id>/submissions/<id>`     |
+| judgements      | `/contests/<id>/judgements/<id>`      |
+| runs            | `/contests/<id>/runs/<id>`            |
+| clarifications  | `/contests/<id>/clarifications/<id>`  |
+| awards          | `/contests/<id>/awards/<id>`          |
+
 Each event is a notification that an object or a collection has changed
 (and hence the contents of the corresponding endpoint) to `data`.
 
-If `type` is `contest`, then the contest at `/contests/<id>` now has the contents of `data`.
+If `type` is `contest`, then `id` must be null, and the contest at `/contests/<id>` now has the contents of `data`.
 If `id` is not null, then the object at `/contests/<contest_id>/<type>/<id>` now has the contents of `data`.
 If `id` is null, then the entire collection at `/contests/<contest_id>/<type>` now has the contents of `data`.
 
@@ -362,6 +382,7 @@ If `id` is null, then the entire collection at `/contests/<contest_id>/<type>` n
 Event:
 ```json
 {
+   "type": "contest",
    "data": {
       "id": "dress2016",
       "name": "2016 ICPC World Finals Dress Rehearsal",


### PR DESCRIPTION
As discussed on the call today, the event feed was receiving a redundant contest_id and the webhook was inconsistent in whether the callback would have one or more notification objects (and what the format was if more than one). This contains a few changes:
- Revert notification `endpoint` to `type`. This is one less change from the current spec, focuses on the contest object vs the REST API, and avoids some minor terminology confusion.
- Remove `contest_id` attribute from notification format. For event-feed this is already implied (you can only add a webhook to one contest), and for webhook each callback should have an array of notifications for only one contest per callback.
- Change webhook callback to an object that contains contest_id and an array of notification objects for that contest.
- Updated and added examples.

This change keeps the nice property that it would be trivial to convert between webhook and event feed or vice-versa, e.g. if you save every webhook notification array into a file called <contest_id>/event-feed.json as NDJSON, you essentially have a feed.