### PR TITLE
Capabilities and Account endpoint

### DIFF
--- a/Contest_API.md
+++ b/Contest_API.md
@@ -1260,7 +1260,7 @@ Properties of account objects:
 | :----------- | :-------------------- | :-------- | :-------- | :----------
 | id           | ID                    | yes       | no        | Identifier of the account used to make this request.
 | username     | string                | yes       | no        | The account username.
-| team\_id     | ID                    | depends   | yes       | The team that this account is for. Required iff type is `team`.
+| team\_id     | ID                    | no        | yes       | The team that this account is for, if the account is for a team, or one team member.
 | people\_id   | ID                    | no        | yes       | The person that this account is for, if the account is only for one person.
 | capabilities | array of string       | no        | yes       | An array of [capabilities](#capabilities) that the current account has.
 | types        | array of type objects | yes       | no        | An array of type objects, as described below.


### PR DESCRIPTION
I looked at several REST APIs, and the pattern is often /users (for all users), /users/x for a specific user, and /user to get the current user. In more than one case /users/x and /user had different properties.

Following this same pattern, I'm proposing /account to get the currently logged in account. The properties are identical to /accounts where they overlap (id, username, team/people id), but it does not include all of the same properties (e.g. password, IP) and has a couple new ones: capabilities, and a list of types that tells you which types and properties for each you may see. The types list is shared with the notification format.

I've added a section to describe what capabilities are, but not attempt to define any of them. I'd like to focus on the accounts endpoint and capabilities description first, then use separate PR(s) to define the capabilities.