### PR TITLE
Account endpoint

### DIFF
--- a/Contest_API.md
+++ b/Contest_API.md
@@ -1187,7 +1187,7 @@ The following endpoints are associated with accounts:
 | `/contests/<id>/accounts`      | application/json | yes       | JSON array of all accounts with properties as defined in the table below.
 | `/contests/<id>/accounts/<id>` | application/json | yes       | JSON object representing a single account with properties as defined in the table below.
 
-Properties of problem objects:
+Properties of account objects:
 
 | Name              | Type    | Required? | Nullable? | Description
 | :---------------- | :------ | :-------- | :-------- | :----------
@@ -1224,6 +1224,31 @@ Returned data:
 
 ```json
 {"id":"nicky","type":"admin"}
+```
+
+### Account
+
+Provides information on which account the client represents within a given contest.
+
+The following endpoint is associated with an account:
+
+| Endpoint                 | Mime-type        | Required? | Description
+| :----------------------- | :--------------- | :-------- | :----------
+| `/contests/<id>/account` | application/json | yes       | JSON object representing a single account with properties as defined in the [Accounts](#accounts) table above.
+
+This endpoint exists in the API so that the clients can tell which account (and hence which person or team) they are logged in as. It is not
+expected to exist in a contest archive, and will fail with a 401 error code if the client is not authenticated.
+
+#### Examples
+
+Request:
+
+`GET https://example.com/api/contests/wf14/account`
+
+Returned data:
+
+```json
+{"id":"nicky","username":"Nicky"}
 ```
 
 ### Contest state


### PR DESCRIPTION
Replacing PR #81. This just adds a simple /account endpoint to match /accounts, allowing clients to know which account they are authenticated/logged in as.