### PR TITLE
Contest location

### DIFF
--- a/Contest_API.md
+++ b/Contest_API.md
@@ -625,6 +625,10 @@ Properties of contest objects:
 | penalty\_time                | integer       | no        | no        | Penalty time for a wrong submission, in minutes. Only relevant if scoreboard\_type is `pass-fail`.
 | banner                       | array of FILE | no        | yes       | Banner for this contest, intended to be an image with a large aspect ratio around 8:1. Only allowed mime types are image/*.
 | logo                         | array of FILE | no        | yes       | Logo for this contest, intended to be an image with aspect ratio near 1:1. Only allowed mime types are image/*.
+| location                     | object        | no        | yes       | JSON object as specified in the rows below.
+| location.latitude            | number        | depends   | no        | Latitude in degrees. Required iff location is present.
+| location.longitude           | number        | depends   | no        | Longitude in degrees. Required iff location is present.
+
 
 The expected/typical use of `countdown_pause_time` is that once a
 `start_time` is defined and close, the countdown may be paused due to


### PR DESCRIPTION
Adds an optional contest location property (object) matching the organization location. This is already supported by CDS and used by the presentation world maps, e.g. showing submission balloons flying from org location to contest location for judging.