### PR TITLE
Revert problem ordinals to integers

### DIFF
--- a/Contest_API.md
+++ b/Contest_API.md
@@ -1029,7 +1029,7 @@ Properties of problem objects:
 | uuid              | string ?  | UUID of the problem, as defined in the problem package.
 | label             | string    | Label of the problem on the scoreboard, typically a single capitalized letter.
 | name              | string    | Name of the problem.
-| ordinal           | number    | A unique number that determines the order the problems, e.g. on the scoreboard.
+| ordinal           | integer   | A unique number that determines the order the problems, e.g. on the scoreboard.
 | rgb               | string ?  | Hexadecimal RGB value of problem color as specified in [HTML hexadecimal colors](https://en.wikipedia.org/wiki/Web_colors#Hex_triplet), e.g. `#AC00FF` or `#fff`.
 | color             | string ?  | Human readable color description associated to the RGB value.
 | time\_limit       | number ?  | Time limit in seconds per test data set (i.e. per single run). Should be an integer multiple of `0.001`.


### PR DESCRIPTION
In the prior spec problem ordinal used to be ORDINAL type and only allowed integers, now it's a number and hence allows decimal places. I assume this was a mistake in the type cleanup, reverting to integer type.