### PR TITLE
Remove unused account_ids

### DIFF
--- a/Contest_API.md
+++ b/Contest_API.md
@@ -1023,7 +1023,7 @@ Returned data:
 
 ### Problems
 
-The problems to be solved in the contest
+The problems to be solved in the contest.
 
 The following endpoints are associated with problems:
 
@@ -1424,10 +1424,9 @@ Properties of submission objects:
 | Name          | Type            | Description
 | :------------ | :-------------- | :----------
 | id            | ID              | Identifier of the submission. Usable as a label, typically a low incrementing number.
-| language\_id  | ID              | Identifier of the [ language](#languages) submitted for.
-| problem\_id   | ID              | Identifier of the [ problem](#problems) submitted for.
-| team\_id      | ID              | Identifier of the [ team](#teams) that made the submission.
-| account\_id   | ID ?            | The account used to create this submission.
+| language\_id  | ID              | Identifier of the [language](#languages) submitted for.
+| problem\_id   | ID              | Identifier of the [problem](#problems) submitted for.
+| team\_id      | ID              | Identifier of the [team](#teams) that made the submission.
 | time          | TIME            | Timestamp of when the submission was made.
 | contest\_time | RELTIME         | Contest relative time when the submission was made.
 | entry\_point  | string ?        | Code entry point for specific languages.
@@ -1710,7 +1709,6 @@ Properties of clarification message objects:
 | to\_team\_id   | ID ?    | Identifier of the [team](#teams) receiving this reply, `null` iff a reply to all teams or a request sent by a team.
 | reply\_to\_id  | ID ?    | Identifier of clarification this is in response to, otherwise `null`.
 | problem\_id    | ID ?    | Identifier of associated [problem](#problems), `null` iff not associated to a problem.
-| account\_id    | ID ?    | The account used to create this clarification.
 | text           | string  | Question or reply text.
 | time           | TIME    | Time of the question/reply.
 | contest\_time  | RELTIME | Contest time of the question/reply.


### PR DESCRIPTION
Remove account_id from submissions and clarifications before we declare this version of the spec, and do a few really minor fixes. The account was added with the expectation that we would use it at the last finals but plans changed; removing since it hasn't been used and better to add later when we can get feedback.