### PR TITLE
Add submission reference to commentary

### DIFF
--- a/Contest_API.md
+++ b/Contest_API.md
@@ -1980,16 +1980,17 @@ The following endpoints are associated with commentary:
 
 Properties of commentary objects:
 
-| Name          | Type            | Description
-| :------------ | :-------------- | :----------
-| id            | ID              | Identifier of the commentary.
-| time          | TIME            | Time of the commentary message.
-| contest\_time | RELTIME         | Contest time of the commentary message.
-| message       | string          | Commentary message text. May contain special tags referring to endpoint objects using the format `{<endpoint>:<object ID>}`. This is most commonly used for references to [teams](#teams) and [problems](#problems) as `{teams:<team ID>}` and `{problems:<problem ID>}` respectively.
-| tags          | array of string | JSON array of tags describing the message.
-| source_id     | ID ?            | Source [person](#persons) of the commentary message.
-| team\_ids     | array of ID ?   | JSON array of [team](#teams) IDs the message is related to.
-| problem\_ids  | array of ID ?   | JSON array of [problem](#problems) IDs the message is related to.
+| Name            | Type            | Description
+| :-------------- | :-------------- | :----------
+| id              | ID              | Identifier of the commentary.
+| time            | TIME            | Time of the commentary message.
+| contest\_time   | RELTIME         | Contest time of the commentary message.
+| message         | string          | Commentary message text. May contain special tags referring to endpoint objects using the format `{<endpoint>:<object ID>}`. This is most commonly used for references to [teams](#teams) and [problems](#problems) as `{teams:<team ID>}` and `{problems:<problem ID>}` respectively.
+| tags            | array of string | JSON array of tags describing the message.
+| source_id       | ID ?            | Source [person](#persons) of the commentary message.
+| team\_ids       | array of ID ?   | JSON array of [team](#teams) IDs the message is related to.
+| problem\_ids    | array of ID ?   | JSON array of [problem](#problems) IDs the message is related to.
+| submission\_ids | array of ID ?   | JSON array of [submission](#submissions) IDs the message is related to.
 
 For the message, if a literal `{` is needed, `\{` must be used. Similarly for a literal `\`, `\\` must be used.
 


### PR DESCRIPTION
Add references to submission in commentary endpoint.

Requested by Live.

The reference is in the form of an array of IDs. to be consistent with the other references. That said, by far the most common case will be that exactly one submission is referenced.