### PR TITLE
Add missing mime types for streaming video

### DIFF
--- a/Contest_API.md
+++ b/Contest_API.md
@@ -1236,8 +1236,8 @@ Properties of team objects:
 | backup            | array of FILE ? | Latest file backup of the team machine. Only allowed mime type is application/zip.
 | key\_log          | array of FILE ? | Latest key log file from the team machine. Only allowed mime type is text/plain.
 | tool\_data        | array of FILE ? | Latest tool data usage file from the team machine. Only allowed mime type is text/plain.
-| desktop           | array of FILE ? | Streaming video of the team desktop.
-| webcam            | array of FILE ? | Streaming video of the team webcam.
+| desktop           | array of FILE ? | Streaming video of the team desktop. Only allowed mime types are video/*.
+| webcam            | array of FILE ? | Streaming video of the team webcam. Only allowed mime types are video/*.
 | audio             | array of FILE ? | Streaming team audio.
 
 #### Examples


### PR DESCRIPTION
Randomly noticed we were missing the mime type for streaming video, so adding it.

I'm not proposing filling this in for audio for now - although it should be audio/*, the last time we used this we were using the same mpeg-2 transport stream as video (i.e. video/mp2t) but with only an audio stream. I can't figure out an equivalent audio/* mime type for this. We have other options now, but I'd prefer to switch in practice and then update the spec vs the other way around.