### PR TITLE
Reset master relative to 2022-07

### DIFF
--- a/Contest_API.md
+++ b/Contest_API.md
@@ -581,7 +581,7 @@ Properties of version object:
 
 | Name        | Type            | Description
 | :---------- | :-------------- | :----------
-| version     | string          | Version of the API. For this version must be the string `2022-07-draft`. Will be of the form `<yyyy>-<mm>`, `<yyyy>-<mm>-draft`, or simply `draft`.
+| version     | string          | Version of the API. For this version must be the string `draft`. Will be of the form `<yyyy>-<mm>`, `<yyyy>-<mm>-draft`, or simply `draft`.
 | version_url | string          | Link to documentation for this version of the API.
 | name        | string ?        | Name of this data provider.
 | logo        | array of FILE ? | Logo for this data provider, intended to be an image with aspect ratio near 1:1. Only allowed mime types are image/*. The different files in the array should be different file formats and/or sizes of the same image.
@@ -596,8 +596,8 @@ Returned data:
 
 ```json
 {
-   "version": "2022-07-draft",
-   "version_url": "https://ccs-specs.icpc.io/2022-07-draft/contest_api",
+   "version": "draft",
+   "version_url": "https://ccs-specs.icpc.io/draft/contest_api",
    "name": "Kattis",
    "logo": [{
       "href": "/api/logo",

--- a/readme.md
+++ b/readme.md
@@ -20,37 +20,11 @@ There are multiple versions of the CCS specifications available on the
 
 This is the draft of some future version of the CCS specification.
 
-## Changes compared to the `2021-11` version
+## Changes compared to the `2022-07` version
 
-These are the main changes made since the `2021-11` version:
+These are the main changes made since the `2022-07` version:
 
-* Access restrictions have been moved from the Contest API specification to
-  the CCS system requirements document.
-* `ORDINAL` types are removed.
-* `IMAGE`, `VIDEO`, `ARCHIVE` and `STREAM` types are now of type `FILE`.
-* Nullable types are added.
-* `FILE` types now have a `filename` and `hash` property.
-* The format of the event feed changed.
-* The event feed now supports reconnection tokens.
-* A new API information endpoint has been added.
-* A new Access endpoint has been added.
-* Specific permissions have been replaced with a generic capabilities approach.
-* Renamed the Team members endpoint to Persons and made `team_id` in it optional.
-* A new Accounts endpoint has been added.
-* The CCS system requirements document specifies the required minimal access restrictions
-  and the capabilities required by a CCS for the World Finals.
-* Groups now support a `location` attribute.
-* Performing a `POST` or `PUT` for the Submissions endpoint is now more generally available
-  depending on the capabilities of an account.
-* Performing a `POST` for the Clarification endpoint is now more generally available depending
-  on the capabilities of an account.
-* The Commentary endpoint now has a `tags`, `source_id` and `submission_ids` property and the
-  mesage format changed.
-* It is no longer possible to request the scoreboard at the time of a given event and the `event_id`
-  property is dropped from the response.
-* Importing contest configuration is no longer done through TSV files, but using a contest package.
-* Contest Archive has been renamed to Contest Package.
-* Add package and statement to Problem endpoint.
+* None yet.
 
 ## References
 


### PR DESCRIPTION
Version `2022-07` has been released, `master` is now a draft of the next (yet unnamed) version and the changelog should compare to `2022-07`.