### PR TITLE
Readme cleanup

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,24 +1,23 @@
-# Contest Control System specifications
+# 2022-07 Contest Control System (CCS) specification
 
-This repository contains a set of related specifications for
-interoperability between different contest control systems and tooling
-that interacts with it. These specifications have been designed and
-used in the contest of the ICPC World Finals, and have also been used
-at various (sub)regionals; they are meant to be useful outside an ICPC
-context as well.
+This branch contains the 2022-07 CCS specification for
+interoperability between different contest control systems and tools
+that interact with them. These specifications have been designed and
+used in the context of the [ICPC World Finals](https://icpc.global)
+and various (sub)regionals, but they are meant to be useful outside
+the ICPC context as well.
 
 The following specifications are present:
 
 * Contest Control System requirements for the ICPC World Finals
 * Contest API: an API specification for accessing information
   provided by a CCS.
-* Contest Archive Format: a format closely related to the Contest API
-  for storing a contest on disk for archival.
+* Contest Package Format: a format closely related to the Contest API
+  for storing contest information on disk.
 
-There are multiple versions of the CCS specifications available on the
-[documentation pages](https://ccs-specs.icpc.io/).
-
-This is the `2022-07` release of the CCS specification..
+This is the `2022-07` release of the CCS specification.
+Other versions of the CCS specifications are available
+[here](https://ccs-specs.icpc.io/).
 
 ## Changes compared to the `2021-11` version
 
@@ -56,5 +55,4 @@ These are the main changes made since the `2021-11` version:
 
 * Website: <https://ccs-specs.icpc.io>
 * Github: <https://github.com/icpc/ccs-specs>
-
-The problem package format specification can be found at: <https://icpc.io/problem-package-format/>
+* Problem package format specification: <https://icpc.io/problem-package-format/>


### PR DESCRIPTION
Changes:
- Made the release more prominent
- Cleaned up text similar to the gh_pages readme.
- CAF -> Contest Package Format