### PR TITLE
2021-11 readme cleanup

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,11 +1,11 @@
-# Contest Control System specifications
+# 2021-11 Contest Control System (CCS) specification
 
-This repository contains a set of related specifications for
-interoperability between different contest control systems and tooling
-that interact with it. These specifications have been designed and
-used in the contest of the ICPC Word Finals, and have also been used
-at various (sub)regionals; they are meant to be useful outside an ICPC
-context as well.
+This branch contains the 2021-11 CCS specification for
+interoperability between different contest control systems and tools
+that interact with them. These specifications have been designed and
+used in the context of the [ICPC World Finals](https://icpc.global)
+and various (sub)regionals, but they are meant to be useful outside
+the ICPC context as well.
 
 The following specifications are present:
 
@@ -13,12 +13,11 @@ The following specifications are present:
 * Contest API: an API specification for accessing information
   provided by a CCS.
 * Contest Archive Format: a format closely related to the Contest API
-  for storing a contest on disk for archival.
-
-There are multiple versions of the CCS specifications available on the
-[documentation pages](https://ccs-specs.icpc.io/).
+  for storing contest information on disk.
 
 This is the `2021-11` release of the CCS specification.
+Other versions of the CCS specifications are available
+[here](https://ccs-specs.icpc.io/).
 
 ## Changes compared to the `2020-03` version
 
@@ -47,5 +46,4 @@ These are the main changes made since the `2020-03` version:
 
 * Website: <https://ccs-specs.icpc.io>
 * Github: <https://github.com/icpc/ccs-specs>
-
-The problem package format specification can be found at: <https://icpc.io/problem-package-format/>
+* Problem package format specification: <https://icpc.io/problem-package-format/>


### PR DESCRIPTION
Changes:
- Made the release more prominent.
- Cleaned up text similar to the 2022-07 readme.