### PR TITLE
Person Clarifications

### DIFF
--- a/Contest_API.md
+++ b/Contest_API.md
@@ -1271,7 +1271,7 @@ Properties of person objects:
 | :---------- | :-------------- | :----------
 | id          | ID              | Identifier of the person.
 | icpc\_id    | string ?        | External identifier from ICPC CMS.
-| team\_id    | ID ?            | [Team](#teams) of this person. Required iff role is `contestant` or `coach`.
+| team\_id    | ID ?            | [Team](#teams) of this person. Required iff role is `contestant`.
 | name        | string          | Name of the person.
 | title       | string ?        | Title of the person, e.g. "Technical director".
 | email       | string ?        | Email of the person.

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -1271,12 +1271,12 @@ Properties of person objects:
 | :---------- | :-------------- | :----------
 | id          | ID              | Identifier of the person.
 | icpc\_id    | string ?        | External identifier from ICPC CMS.
-| team\_id    | ID ?            | [Team](#teams) of this person. Required iff role is `team`.
+| team\_id    | ID ?            | [Team](#teams) of this person. Required iff role is `contestant` or `coach`.
 | name        | string          | Name of the person.
 | title       | string ?        | Title of the person, e.g. "Technical director".
 | email       | string ?        | Email of the person.
 | sex         | string ?        | Either `male` or `female`, or possibly `null`.
-| role        | string          | One of `contestant`, `coach`, or `staff`.
+| role        | string          | One of `contestant`, `coach`, `staff`, or `other`.
 | photo       | array of FILE ? | Registration photo of the person. Only allowed mime types are image/*.
 
 #### Examples


### PR DESCRIPTION
Minor clarifications for persons:
- Role didn't match the possible roles, change it to be for coaches and contestants.
- Add 'other' role to account for people that aren't staff or directly on a team, e.g. spare team members, attendees, or local officials that are in CMS.