### PR TITLE
Clarify required endpoints

### DIFF
--- a/Contest_API.md
+++ b/Contest_API.md
@@ -507,7 +507,7 @@ The endpoints can be categorized into 4 groups as follows:
     awards, commentary;
   - Aggregate data: scoreboard, event-feed.
 
-Metadata is data about the API, and are the only required API endpoints. 
+The metadata endpoints contain data about the API, and are the only required API endpoints. 
 They are not included in the event feed. The access endpoint specifies
 which other endpoints are offered by the API.
 

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -531,7 +531,7 @@ NDJSON format.
 Note that `api`, `access`, `account`, `state`, `scoreboard`, and `event-feed`
 are singular nouns and indeed contain only a single object.
 
-### Required and Optional API
+### Required and optional endpoints
 
 The only required endpoints are metadata: `api` and `access`. The
 only required property is `id` (if it exists on the endpoint).

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -331,8 +331,6 @@ access to.
 | [admin_submit](#modifying-submissions)    | Submit as an admin                           |
 | [admin_clar](#modifying-clarifications)   | Submit clarifications as an admin            |
 
-TODO - add capabilities related to team view, awards, and freeze time.
-
 ### Notification format
 
 There are two mechanisms that clients can use to receive notifications
@@ -495,10 +493,6 @@ are meant to ease extensibility:
 
 ## Interface specification
 
-The following list of API endpoints should be supported. Note that `access`,
-`state`, `scoreboard` and `event-feed` are singular nouns and indeed
-contain only a single object.
-
 All endpoints should support `GET`; specific details on other methods
 are mentioned below.
 
@@ -513,9 +507,9 @@ The endpoints can be categorized into 4 groups as follows:
     awards, commentary;
   - Aggregate data: scoreboard, event-feed.
 
-Metadata is data about the API. These are not included in the event feed and
-are always required to be available. The access endpoint specifies which other
-endpoints are offered by the API. 
+Metadata is data about the API, and these are the only required API endpoints. 
+These are not included in the event feed. The access endpoint specifies
+which other endpoints are offered by the API.
 
 Configuration is normally set before contest start. Is not expected to,
 but could occasionally be updated during a contest. It does not have
@@ -533,6 +527,33 @@ Aggregate data: Only `GET` makes sense. These are not included in the
 event feed, also note that these should not be considered proper REST
 endpoints, and that the `event-feed` endpoint is a streaming feed in
 NDJSON format.
+
+Note that `access`, `account`, `state`, `scoreboard` and `event-feed`
+are singular nouns and indeed contain only a single object.
+
+### Required and Optional API
+
+The only required endpoints are metadata: `api` and `access`. The
+only required property is `id` (if it exists on the endpoint).
+
+All other endpoints and properties are optional. The only exceptions
+to this are obvious logical requirements (for example, a submission
+must come from a team) and the requirement for referential integrity
+(for example, if a submission has a team_id, then teams must be supported).
+`access` exists so that you can discover which endpoints and properties
+are supported by a given provider.
+
+In practice there are different types of providers that will offer
+similar sets of endpoints. Some examples:
+ - A contest management system will support at least contests and
+   teams, and may support other configuration endpoints.
+ - A Contest Control System (CCS) will support at least submissions,
+   judgements, and dependencies of these, as well as scoreboard and
+   event-feed.
+
+Separate specifications (for example, the CCS System Requirements)
+will provide more information on which endpoints and properties
+can be expected, often in the form of a minimal `access` response.
 
 ### Table column description
 

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -536,7 +536,7 @@ are singular nouns and indeed contain only a single object.
 
 The only required endpoints are metadata: `api` and `access`.
 The only requirements for properties are that collections must have
-an `id` property, and all endpoints that are supported must
+an `id` property.
 have at least some property, i.e. an endpoint can't be empty.
 [Referential integrity](#referential-integrity) must also be kept
 (for example, if a submission has a team_id, then teams must be supported).

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -7,7 +7,7 @@ permalink: /contest_api
 ## Introduction
 
 This page describes an API for accessing information provided by a
-[Contest Control System](ccs_system_requirements) or
+[Contest Control System](ccs_system_requirements) (CCS) or
 [Contest Data Server](https://tools.icpc.global/cds/).
 Such an API can be used by a multitude of clients:
 
@@ -493,7 +493,7 @@ are meant to ease extensibility:
 
 ## Interface specification
 
-The following list of API endpoints may be supported.
+The following list of API endpoints may be supported, as detailed below.
 All endpoints should support `GET`; specific details on other methods
 are mentioned below.
 
@@ -549,9 +549,9 @@ In practice there are different types of providers that will offer
 similar sets of endpoints. Some examples:
  - A contest management system will support at least contests and
    teams, and may support other configuration endpoints.
- - A Contest Control System (CCS) will support at least submissions,
-   judgements, and dependencies of these, as well as scoreboard and
-   event-feed.
+ - A CCS will support at least submissions, judgements, and
+   dependencies of these. It will likely support a scoreboard, and
+   usually an event-feed.
 
 Separate specifications (for example, the CCS System Requirements)
 will provide more information on which endpoints and properties
@@ -575,7 +575,7 @@ Note that all results returned from endpoints:
   - Must only have `null` values if the type of the property is `<type> ?`.
   - Must contain all properties specified in the [Access](#access) endpoint
     that have non-`null` values. 
-  - Should not contain any properties not specified in the [Access](#access) 
+  - Must not contain any properties not specified in the [Access](#access) 
     endpoint.
 
 ### Filtering

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -537,7 +537,6 @@ are singular nouns and indeed contain only a single object.
 The only required endpoints are metadata: `api` and `access`.
 The only requirements for properties are that collections must have
 an `id` property.
-have at least some property, i.e. an endpoint can't be empty.
 [Referential integrity](#referential-integrity) must also be kept
 (for example, if a submission has a team_id, then teams must be supported).
 

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -493,6 +493,7 @@ are meant to ease extensibility:
 
 ## Interface specification
 
+The following list of API endpoints may be supported.
 All endpoints should support `GET`; specific details on other methods
 are mentioned below.
 
@@ -533,13 +534,14 @@ are singular nouns and indeed contain only a single object.
 
 ### Required and optional endpoints
 
-The only required endpoints are metadata: `api` and `access`. The
-only required property is `id` (if it exists on the endpoint).
-
-All other endpoints and properties are optional. The only exceptions
-to this are obvious logical requirements (for example, a submission
-must come from a team) and the requirement for referential integrity
+The only required endpoints are metadata: `api` and `access`.
+The only requirements for properties are that collections must have
+an `id` property, and all endpoints that are supported must
+have at least some property, i.e. an endpoint can't be empty.
+[Referential integrity](#referential-integrity) must also be kept
 (for example, if a submission has a team_id, then teams must be supported).
+
+All other endpoints and properties are optional.
 `access` exists so that you can discover which endpoints and properties
 are supported by a given provider.
 

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -528,7 +528,7 @@ event feed, also note that these should not be considered proper REST
 endpoints, and that the `event-feed` endpoint is a streaming feed in
 NDJSON format.
 
-Note that `access`, `account`, `state`, `scoreboard` and `event-feed`
+Note that `api`, `access`, `account`, `state`, `scoreboard`, and `event-feed`
 are singular nouns and indeed contain only a single object.
 
 ### Required and Optional API

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -507,7 +507,7 @@ The endpoints can be categorized into 4 groups as follows:
     awards, commentary;
   - Aggregate data: scoreboard, event-feed.
 
-Metadata is data about the API, and these are the only required API endpoints. 
+Metadata is data about the API, and are the only required API endpoints. 
 These are not included in the event feed. The access endpoint specifies
 which other endpoints are offered by the API.
 

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -509,7 +509,7 @@ The endpoints can be categorized into 4 groups as follows:
 
 The metadata endpoints contain data about the API, and are the only required API endpoints. 
 They are not included in the event feed. The access endpoint specifies
-which other endpoints are offered by the API.
+which other endpoints are offered by the API. That is, any endpoints and their properties listed in `access` must be provided (possibly with a `null` value when the property is optional), and only these endpoints and properties. 
 
 Configuration is normally set before contest start. Is not expected to,
 but could occasionally be updated during a contest. It does not have

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -508,7 +508,7 @@ The endpoints can be categorized into 4 groups as follows:
   - Aggregate data: scoreboard, event-feed.
 
 Metadata is data about the API, and are the only required API endpoints. 
-These are not included in the event feed. The access endpoint specifies
+They are not included in the event feed. The access endpoint specifies
 which other endpoints are offered by the API.
 
 Configuration is normally set before contest start. Is not expected to,


### PR DESCRIPTION
- Removed TODO (still in master branch).
- Removed "The following list of API endpoints should be supported", because that seems wrong, or confusing at best.
- Moved 'singular noun' sentence down because it seemed out of place, and added missing `account`.
- Reworded the metadata endpoint sentence.
- Added section on 'Required and Optional API'. There is some redundancy with the metadata paragraph, but I felt it was appropriate.