### PR TITLE
Drop -o a.out from example.

### DIFF
--- a/Contest_API.md
+++ b/Contest_API.md
@@ -1086,7 +1086,7 @@ Returned data:
    "name": "GNU C++",
    "compiler": {
       "command": "gcc",
-      "args": "-O2 -Wall -o a.out -static {files}",
+      "args": "-O2 -Wall -static {files}",
       "version": "gcc (Ubuntu 8.3.0-6ubuntu1) 8.3.0"
    },
    "entry_point_required": false,


### PR DESCRIPTION
It is misleading that only one example has this and it's even the default.