### PR TITLE
Cherry pick 'Ignore checking for access endpoint in the event feed for now.'

### DIFF
--- a/check-api-consistency.php
+++ b/check-api-consistency.php
@@ -107,6 +107,8 @@ foreach ($feed_data as $endpoint => $elements) {
 
 // Now check that each REST endpoint element appears in the feed.
 foreach ($endpoints as $endpoint) {
+    # TODO: decide whether access should be in the feed:
+    if ($endpoint==='access') continue;
     $endpoint_json = json_decode(file_get_contents($dir.'/'.$endpoint.'.json'), true);
     if (in_array($endpoint,['contests','state'])) $endpoint_json = [$endpoint_json];
     foreach ($endpoint_json as $element) {


### PR DESCRIPTION
DOMjudge uses this script to verify their implementation and our CI currently breaks.