### PR TITLE
Fix Issue #164 - change access endpoint example

### DIFF
--- a/Contest_API.md
+++ b/Contest_API.md
@@ -706,7 +706,7 @@ Returned data:
 
 ```json
 {
-   "capabilities": ["patch_time"],
+   "capabilities": ["contest_start"],
    "endpoints": [
      { "type": "contests", "properties": ["id","name","formal_name",...]},
      { "type": "problems", "properties": ["id","label",...]},

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -1086,7 +1086,7 @@ Returned data:
    "name": "GNU C++",
    "compiler": {
       "command": "gcc",
-      "args": "-O2 -Wall -o a.out -static {files}",
+      "args": "-O2 -Wall -static {files}",
       "version": "gcc (Ubuntu 8.3.0-6ubuntu1) 8.3.0"
    },
    "entry_point_required": false,

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -612,7 +612,7 @@ Properties of version object:
 
 | Name         | Type              | Description
 | :----------- | :---------------- | :----------
-| version      | string            | Version of the API. For this version must be the string `draft`. Will be of the form `<yyyy>-<mm>`, `<yyyy>-<mm>-draft`, or simply `draft`.
+| version      | string            | Version of the API. For this version must be the string `2023-06`. Will be of the form `<yyyy>-<mm>`, `<yyyy>-<mm>-draft`, or simply `draft`.
 | version\_url | string            | Link to documentation for this version of the API.
 | provider     | provider object ? | Information about the data provider
 
@@ -634,8 +634,8 @@ Returned data:
 
 ```json
 {
-   "version": "draft",
-   "version_url": "https://ccs-specs.icpc.io/draft/contest_api",
+   "version": "2023-06",
+   "version_url": "https://ccs-specs.icpc.io/2023-06/contest_api",
    "provider" : {
       "name": "DOMjudge",
       "version" : "8.3.0DEV/4ac31de71",

--- a/check-api-consistency.php
+++ b/check-api-consistency.php
@@ -107,6 +107,8 @@ foreach ($feed_data as $endpoint => $elements) {
 
 // Now check that each REST endpoint element appears in the feed.
 foreach ($endpoints as $endpoint) {
+    # TODO: decide whether access should be in the feed:
+    if ($endpoint==='access') continue;
     $endpoint_json = json_decode(file_get_contents($dir.'/'.$endpoint.'.json'), true);
     if (in_array($endpoint,['contests','state'])) $endpoint_json = [$endpoint_json];
     foreach ($endpoint_json as $element) {

--- a/check-api.sh
+++ b/check-api.sh
@@ -3,7 +3,7 @@ set -e -o pipefail
 
 # This should match the API version this script tests as found at the
 # URL https://ccs-specs.icpc.io/$API_VERSION/contest_api
-API_VERSION=draft
+API_VERSION=2023-06
 
 ENDPOINTS='
 contests

--- a/json-schema/api_information.json
+++ b/json-schema/api_information.json
@@ -8,7 +8,7 @@
 	"properties": {
 		"version": {
 			"type": "string",
-			"const": "draft"
+			"const": "2023-06"
 		},
 		"version_url": { "type": "string" },
 		"provider": {

--- a/readme.md
+++ b/readme.md
@@ -19,10 +19,9 @@ Furthermore, a tool and JSON schema specifications are available to
 validate an implementation of the Contest API. Run `check-api.sh -h`
 from the root of the repository for usage information.
 
-There are multiple versions of the CCS specifications available on the
-[documentation pages](https://ccs-specs.icpc.io/).
-
-This is the draft of some future version of the CCS specification.
+This is the `2023-06` release of the CCS specification.
+Other versions of the CCS specifications are available
+[here](https://ccs-specs.icpc.io/).
 
 ## Changes compared to the `2022-07` version
 


### PR DESCRIPTION
One of the examples for the `Access `endpoint showed a capability of "**patch_time**".  This capability does not appear in the **Capabilities** list that says "_All capabilities are listed in the table below_".  Clearly, "**patch_time**" is not in the list.  For clarity, it makes sense to change the example to use a documented property.   "**contest_start"** makes the most sense here.
This fixes Issue #164 