### PR TITLE
Add `current` to `/judgements`

### DIFF
--- a/Contest_API.md
+++ b/Contest_API.md
@@ -531,7 +531,7 @@ Data is immutable though: only inserts, no updates or deletes of
 objects. It does have associated timestamp/contest time property.
 Inserts and deletes are notified via the event feed. **Note**:
 judgements are the exception to immutability in a weak sense: they get
-updated once with the final verdict.
+updated once with the final verdict, and the value for `current` may change.
 
 Aggregate data: Only `GET` makes sense. These are not included in the
 event feed, also note that these should not be considered proper REST
@@ -1709,6 +1709,7 @@ Properties of judgement objects:
 | submission\_id       | ID        | Identifier of the [submission](#submissions) judged.
 | judgement\_type\_id  | ID ?      | The [verdict](#judgement-types) of this judgement. Required iff judgement has completed.
 | score                | number    | Score for this judgement. Required iff contest:scoreboard\_type is `score`.
+| current              | boolean ? | `true` if this is the current judgement. Defaults to `true`. At most one judgement per submission can ever have this `true`.
 | start\_time          | TIME      | Absolute time when judgement started.
 | start\_contest\_time | RELTIME   | Contest relative time when judgement started.
 | end\_time            | TIME ?    | Absolute time when judgement completed. Required iff judgement\_type\_id is present.

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -1709,7 +1709,7 @@ Properties of judgement objects:
 | submission\_id       | ID        | Identifier of the [submission](#submissions) judged.
 | judgement\_type\_id  | ID ?      | The [verdict](#judgement-types) of this judgement. Required iff judgement has completed.
 | score                | number    | Score for this judgement. Required iff contest:scoreboard\_type is `score`.
-| current              | boolean ? | `true` if this is the current judgement. Defaults to `true`. At most one judgement per submission can ever have this `true`.
+| current              | boolean ? | `true` if this is the current judgement. Defaults to `true`. At any time, there must be at most one judgement per submission for which this `true` or unset (and thus defaulting to `true`).
 | start\_time          | TIME      | Absolute time when judgement started.
 | start\_contest\_time | RELTIME   | Contest relative time when judgement started.
 | end\_time            | TIME ?    | Absolute time when judgement completed. Required iff judgement\_type\_id is present.

--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ This is the draft of some future version of the CCS specification.
 
 These are the main changes made since the `2023-06` version:
 
-- Changed type of `penalty_time` in contest enpoint from `integer` to `RELTIME`.
+- Changed type of `penalty_time` in contest endpoint from `integer` to `RELTIME`.
 - Changed type of time related properties in scoreboard endpoint from `integer` to `RELTIME`.
 - Added `current` to judgements endpoint.
 

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,7 @@ These are the main changes made since the `2023-06` version:
 
 - Changed type of `penalty_time` in contest enpoint from `integer` to `RELTIME`.
 - Changed type of time related properties in scoreboard endpoint from `integer` to `RELTIME`.
+- Added `current` to judgements endpoint.
 
 ## References
 


### PR DESCRIPTION
Fixes #53.

Quick summary of the discussion in #53:

> **Problem**: In the case of rejudgements most (all?) of our current implementations will emit a second judgement for a submission on the event-feed. It is not actually specified which judgement should count when there are many.
> 
> **Workaround**: In practice it will always be the latest one, but in theory it could not be (but that's not specified anyway).
> 
> **Solutions**: Based on the discussios there seem to be two clear options:
> 1. Add a `current` field to `/judgements`. Make it default to true. Require that at most one is true at any time.
> 2. Clarify that there can only ever be one judgement per submission in the API

Both solutions would work, and both would somewhat break the immutability property of [live data](https://ccs-specs.icpc.io/draft/contest_api#types-of-endpoints). That said, it was already not absolute, since judgements were allowed to get updated once. One could argue that only (additionally) allowing deletions (i.e. option 2 above) is a bit cleaner than allowing `current` to be changed, but the difference is IMO small.

I opted for option 2 because it is slightly more powerful. It allows (but does *not* require, in fact it is still required to **be able** to not do so) a CCS to "leak" an ongoing rejudge, which *could* be of interest.
