### PR TITLE
Allow multiple teams and groups in clarification destinations

### DIFF
--- a/Contest_API.md
+++ b/Contest_API.md
@@ -1809,7 +1809,7 @@ Properties of clarification message objects:
 | time           | TIME             | Time of the question/reply.
 | contest\_time  | RELTIME          | Contest time of the question/reply.
 
-The recipients of a clarification are the union of `to_team_ids` and `to_group_ids`.  If `from_team_id` and both `to_team_ids` and `to_group_ids` are `null`, then the clarification is sent to all teams.  Note that if `from_team_id` is not `null`, then both `to_team_ids` and `to_group_ids` must be `null`. That is, teams cannot send messages to other teams or groups.
+The recipients of a clarification are the union of `to_team_ids` and `to_group_ids`.  A clarification is sent to all teams if `from_team_id` is null and the union of `to_team_ids` and `to_group_ids` is empty.  Note that if `from_team_id` is not `null`, then both `to_team_ids` and `to_group_ids` must be `null`. That is, teams cannot send messages to other teams or groups.
 
 #### Modifying clarifications
 

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -594,8 +594,8 @@ Note that all results returned from endpoints:
 Endpoints that return a JSON array must allow filtering on any
 property with type ID (except the `id` property) by passing it as a
 query argument. For example, clarifications can be filtered on the
-recipient by passing `to_team_id=X`. To filter on a `null` value,
-pass an empty string, i.e. `to_team_id=`. It must be possible to
+recipient by passing `to_team_ids=X,Y`. To filter on a `null` value,
+pass an empty string, i.e. `to_team_ids=`. It must be possible to
 filter on multiple different properties simultaneously, with the
 meaning that all conditions must be met (they are logically `AND`ed).
 Note that filtering on any other property, including property with the type

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -1800,7 +1800,7 @@ Properties of clarification message objects:
 | Name           | Type             | Description
 | :------------- | :--------------- | :----------
 | id             | ID               | Identifier of the clarification.
-| from\_team\_id | ID ?             | Identifier of [team](#teams) sending this clarification request, `null` iff a clarification sent by jury.
+| from\_team\_id | ID ?             | Identifier of the [team](#teams) sending this clarification request, `null` iff a clarification is sent by the jury.
 | to\_team\_ids  | array of ID ?    | Identifiers of the [team(s)](#teams) receiving this reply, `null` iff a reply to all teams or a request sent by a team.
 | to\_group\_ids | array of ID ?    | Identifiers of the [ group(s)](#groups) receiving this reply, `null` iff a reply to all teams or a request sent by a team.
 | reply\_to\_id  | ID ?             | Identifier of clarification this is in response to, otherwise `null`.
@@ -1809,9 +1809,7 @@ Properties of clarification message objects:
 | time           | TIME             | Time of the question/reply.
 | contest\_time  | RELTIME          | Contest time of the question/reply.
 
-Note that at least one of `from_team_id` and (`to_team_ids` or `to_group_ids`) has to be
-`null`. That is, teams cannot send messages to other teams or groups.  In order to send a reply
-to all teams, both `to_team_ids` and `to_group_ids` must be `null`.
+The recipients of a clarification are the union of `to_team_ids` and `to_group_ids`.  If `from_team_id` and both `to_team_ids` and `to_group_ids` are `null`, then the clarification is sent to all teams.  Note that if `from_team_id` is not `null`, then both `to_team_ids` and `to_group_ids` must be `null`. That is, teams cannot send messages to other teams or groups.
 
 #### Modifying clarifications
 
@@ -1834,12 +1832,12 @@ exceptions:
   choose to include or exclude the `problem_id`.
 - The `post_clar` capability only has access to `POST`. `id`,
   `time`, and `contest_time` must not be provided. When submitting from a
-  team account, `to_team_id` must not be provided; `from_team_id` may be
+  team account, `to_team_ids` and `to_group_ids` must not be provided; `from_team_id` may be
   provided but then must match the ID of the team associated with the request.
   When submitting from a judge account, `from_team_id` must not be provided.
   In either case the server will determine an `id` and the current `time` and
   `contest_time`.
-- The `proxy_clar` capability only has access to `POST`. `id`, `to_team_id`,
+- The `proxy_clar` capability only has access to `POST`. `id`, `to_team_ids`, `to_group_ids`,
   `time`, and `contest_time` must not be provided. `from_team_id` must be
   provided. The server will determine an `id` and the current `time` and
   `contest_time`.
@@ -1851,7 +1849,7 @@ The request must fail with a 4xx error code if any of the following happens:
 
 - A required property is missing.
 - A property that must not be provided is provided.
-- The supplied problem, from\_team, to\_team, or reply\_to cannot be found or are
+- The supplied problem, `from_team`, `to_team_ids`, `to_group_ids`, or `reply_to` cannot be found or are
   not visible to the client that's submitting.
 - The provided `id` already exists or is otherwise not acceptable.
 
@@ -1869,7 +1867,7 @@ Request:
 Returned data:
 
 ```json
-[{"id":"wf2017-1","from_team_id":null,"to_team_id":null,"reply_to_id":null,"problem_id":null,
+[{"id":"wf2017-1","from_team_id":null,"to_team_ids":null,"to_group_ids":null,"reply_to_id":null,"problem_id":null,
   "text":"Do not touch anything before the contest starts!","time":"2014-06-25T11:59:27.543+01","contest_time":"-0:15:32.457"}
 ]
 ```
@@ -1881,9 +1879,9 @@ Request:
 Returned data:
 
 ```json
-[{"id":"1","from_team_id":"34","to_team_id":null,"reply_to_id":null,"problem_id":null,
+[{"id":"1","from_team_id":"34","to_team_ids":null,"to_group_ids":null,"reply_to_id":null,"problem_id":null,
   "text":"May I ask a question?","time":"2017-06-25T11:59:27.543+01","contest_time":"1:59:27.543"},
- {"id":"2","from_team_id":null,"to_team_id":"34","reply_to_id":"1","problem_id":null,
+ {"id":"2","from_team_id":null,"to_team_ids":["34"],"reply_to_id":"1","problem_id":null,
   "text":"Yes you may!","time":"2017-06-25T11:59:47.543+01","contest_time":"1:59:47.543"}
 ]
 ```
@@ -1896,7 +1894,7 @@ Returned data:
 
 ```json
 [{"id":"1","from_team_id":"34","text":"May I ask a question?","time":"2017-06-25T11:59:27.543+01","contest_time":"1:59:27.543"},
- {"id":"2","to_team_id":"34","reply_to_id":"1","text":"Yes you may!","time":"2017-06-25T11:59:47.543+01","contest_time":"1:59:47.543"}
+ {"id":"2","to_team_ids":["34"],"reply_to_id":"1","text":"Yes you may!","time":"2017-06-25T11:59:47.543+01","contest_time":"1:59:47.543"}
 ]
 ```
 

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -1802,7 +1802,7 @@ Properties of clarification message objects:
 | id             | ID               | Identifier of the clarification.
 | from\_team\_id | ID ?             | Identifier of the [team](#teams) sending this clarification request, `null` iff a clarification is sent by the jury.
 | to\_team\_ids  | array of ID ?    | Identifiers of the [team(s)](#teams) receiving this reply, `null` iff a reply to all teams or a request sent by a team.
-| to\_group\_ids | array of ID ?    | Identifiers of the [ group(s)](#groups) receiving this reply, `null` iff a reply to all teams or a request sent by a team.
+| to\_group\_ids | array of ID ?    | Identifiers of the [group(s)](#groups) receiving this reply, `null` iff a reply to all teams or a request sent by a team.
 | reply\_to\_id  | ID ?             | Identifier of clarification this is in response to, otherwise `null`.
 | problem\_id    | ID ?             | Identifier of associated [problem](#problems), `null` iff not associated to a problem.
 | text           | string           | Question or reply text.
@@ -1894,7 +1894,7 @@ Returned data:
 
 ```json
 [{"id":"1","from_team_id":"34","text":"May I ask a question?","time":"2017-06-25T11:59:27.543+01","contest_time":"1:59:27.543"},
- {"id":"2","to_team_ids":["34"],"reply_to_id":"1","text":"Yes you may!","time":"2017-06-25T11:59:47.543+01","contest_time":"1:59:47.543"}
+ {"id":"2","to_team_ids":["34","57","69"],"to_group_ids":["1336"], "reply_to_id":"1","text":"Yes you may!","time":"2017-06-25T11:59:47.543+01","contest_time":"1:59:47.543"}
 ]
 ```
 

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -1809,7 +1809,7 @@ Properties of clarification message objects:
 | time           | TIME             | Time of the question/reply.
 | contest\_time  | RELTIME          | Contest time of the question/reply.
 
-The recipients of a clarification are the union of `to_team_ids` and `to_group_ids`.  A clarification is sent to all teams if `from_team_id` is null and the union of `to_team_ids` and `to_group_ids` is empty.  Note that if `from_team_id` is not `null`, then both `to_team_ids` and `to_group_ids` must be `null`. That is, teams cannot send messages to other teams or groups.
+The recipients of a clarification are the union of `to_team_ids` and `to_group_ids`.  A clarification is sent to all teams if `from_team_id`, `to_team_ids` and `to_group_ids` are null.  Note that if `from_team_id` is not `null`, then both `to_team_ids` and `to_group_ids` must be `null`. That is, teams cannot send messages to other teams or groups.
 
 #### Modifying clarifications
 

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -1809,7 +1809,7 @@ Properties of clarification message objects:
 | time           | TIME             | Time of the question/reply.
 | contest\_time  | RELTIME          | Contest time of the question/reply.
 
-Note that at least one of `from_team_id` and `to_team_ids` or `to_group_ids` has to be
+Note that at least one of `from_team_id` and (`to_team_ids` or `to_group_ids`) has to be
 `null`. That is, teams cannot send messages to other teams or groups.  In order to send a reply
 to all teams, both `to_team_ids` and `to_group_ids` must be `null`.
 

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -593,9 +593,10 @@ Note that all results returned from endpoints:
 
 Endpoints that return a JSON array must allow filtering on any
 property with type ID (except the `id` property) by passing it as a
-query argument. For example, clarifications can be filtered on the
-recipient by passing `to_team_ids=X,Y`. To filter on a `null` value,
-pass an empty string, i.e. `to_team_ids=`. It must be possible to
+query argument. For example, clarifications can be filtered on the sender
+by passing `from_team_id=X`. To filter on a `null` value,
+pass an empty string, i.e. `from_team_id=`. Properties of type ID ? can only
+be filtered on if the property is present.  It must be possible to
 filter on multiple different properties simultaneously, with the
 meaning that all conditions must be met (they are logically `AND`ed).
 Note that filtering on any other property, including property with the type
@@ -686,7 +687,7 @@ The set of properties listed must always support
 [referential integrity](#referential-integrity), i.e. if a property with a ID 
 value referring to some type of object is present the endpoint representing
 that type of object (and its ID property) must also be present. E.g. if 
-`group_ids` is listed among the properties in the `team` endpoint object, that
+`groups` is listed among the properties in the `team` endpoint object, that
 means that there must be an endpoint object with type `groups` containing at 
 least `ID` in its properties.
 

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -1797,19 +1797,21 @@ The following endpoints are associated with clarification messages:
 
 Properties of clarification message objects:
 
-| Name           | Type    | Description
-| :------------- | :------ | :----------
-| id             | ID      | Identifier of the clarification.
-| from\_team\_id | ID ?    | Identifier of [team](#teams) sending this clarification request, `null` iff a clarification sent by jury.
-| to\_team\_id   | ID ?    | Identifier of the [team](#teams) receiving this reply, `null` iff a reply to all teams or a request sent by a team.
-| reply\_to\_id  | ID ?    | Identifier of clarification this is in response to, otherwise `null`.
-| problem\_id    | ID ?    | Identifier of associated [problem](#problems), `null` iff not associated to a problem.
-| text           | string  | Question or reply text.
-| time           | TIME    | Time of the question/reply.
-| contest\_time  | RELTIME | Contest time of the question/reply.
+| Name           | Type             | Description
+| :------------- | :--------------- | :----------
+| id             | ID               | Identifier of the clarification.
+| from\_team\_id | ID ?             | Identifier of [team](#teams) sending this clarification request, `null` iff a clarification sent by jury.
+| to\_team\_ids  | array of ID ?    | Identifiers of the [team(s)](#teams) receiving this reply, `null` iff a reply to all teams or a request sent by a team.
+| to\_group\_ids | array of ID ?    | Identifiers of the [ group(s)](#groups) receiving this reply, `null` iff a reply to all teams or a request sent by a team.
+| reply\_to\_id  | ID ?             | Identifier of clarification this is in response to, otherwise `null`.
+| problem\_id    | ID ?             | Identifier of associated [problem](#problems), `null` iff not associated to a problem.
+| text           | string           | Question or reply text.
+| time           | TIME             | Time of the question/reply.
+| contest\_time  | RELTIME          | Contest time of the question/reply.
 
-Note that at least one of `from_team_id` and `to_team_id` has to be
-`null`. That is, teams cannot send messages to other teams.
+Note that at least one of `from_team_id` and `to_team_ids` or `to_group_ids` has to be
+`null`. That is, teams cannot send messages to other teams or groups.  In order to send a reply
+to all teams, both `to_team_ids` and `to_group_ids` must be `null`.
 
 #### Modifying clarifications
 

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -595,8 +595,7 @@ Endpoints that return a JSON array must allow filtering on any
 property with type ID (except the `id` property) by passing it as a
 query argument. For example, clarifications can be filtered on the sender
 by passing `from_team_id=X`. To filter on a `null` value,
-pass an empty string, i.e. `from_team_id=`. Properties of type ID ? can only
-be filtered on if the property is present.  It must be possible to
+pass an empty string, i.e. `from_team_id=`. It must be possible to
 filter on multiple different properties simultaneously, with the
 meaning that all conditions must be met (they are logically `AND`ed).
 Note that filtering on any other property, including property with the type

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -686,7 +686,7 @@ The set of properties listed must always support
 [referential integrity](#referential-integrity), i.e. if a property with a ID 
 value referring to some type of object is present the endpoint representing
 that type of object (and its ID property) must also be present. E.g. if 
-`groups` is listed among the properties in the `team` endpoint object, that
+`group_ids` is listed among the properties in the `team` endpoint object, that
 means that there must be an endpoint object with type `groups` containing at 
 least `ID` in its properties.
 

--- a/Contest_Control_System_Requirements.md
+++ b/Contest_Control_System_Requirements.md
@@ -1007,7 +1007,7 @@ The following access restrictions must apply to GETs on the API endpoints:
   thawed.
 - For clients with the `public` role the `/clarifications` endpoint must only
   contain replies from the jury to all teams, that is, messages where both
-  `from_team_id` and `to_team_id` are `null`. For clients with the `team` role
+  `from_team_id`, `to_team_ids` and `to_group_ids` are `null`. For clients with the `team` role
   the `/clarifications` endpoint must only contain their own clarifications
   (sent or received) and public clarifications.
 - For clients with the `public` role the `/awards` and `/scoreboard` endpoints


### PR DESCRIPTION
Removed the `to_team_id `property from the clarifications object, and replaced it with `to_team_ids `and `to_groups_ids`.  This allows a clarification response (or announcement) to be sent to multiple teams and/or groups and of course everyone.  

Added a description of how the new properties work.

Changed the clarification examples to reflect the new properties.

Changed **Filtering** example to use `to_team_ids `since it previously used `to_team_id`.

This is a "breaking change" in that clients and servers that expect the `to_team_id` property for clarifications will no longer work properly until they are updated to use the new property(ies).