### PR TITLE
JSON schema fixes for 2023-06 release

### DIFF
--- a/json-schema/access.json
+++ b/json-schema/access.json
@@ -1,5 +1,5 @@
 {
-	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/access.json",
+	"$id": "https://github.com/icpc/ccs-specs/raw/2023-06/json-schema/access.json",
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: access",
 	"description": "JSON response of this API call",

--- a/json-schema/access.json
+++ b/json-schema/access.json
@@ -1,6 +1,6 @@
 {
 	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/access.json",
-	"$schema": "http://json-schema.org/draft/2020-12/schema",
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: access",
 	"description": "JSON response of this API call",
 

--- a/json-schema/account.json
+++ b/json-schema/account.json
@@ -20,6 +20,18 @@
 		"team_id": { "$ref": "common.json#/identifierornull" },
 		"person_id": { "$ref": "common.json#/identifierornull" }
 	},
+	"if": {
+		"properties": {
+			"type": { "enum": [ "team" ] }
+		},
+		"required": [ "type" ]
+	},
+	"then": {
+		"properties": {
+			"team_id": { "$ref": "common.json#/identifier" }
+		},
+		"required": [ "team_id" ]
+	},
 	"required": ["id", "username", "type"],
 	"$comment": "ANCHOR_TO_INSERT_REQUIRE_STRICT_PROPERTIES"
 }

--- a/json-schema/account.json
+++ b/json-schema/account.json
@@ -1,6 +1,6 @@
 {
 	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/account.json",
-	"$schema": "http://json-schema.org/draft/2020-12/schema",
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API - account",
 	"description": "Definition of a single account object",
 

--- a/json-schema/account.json
+++ b/json-schema/account.json
@@ -1,5 +1,5 @@
 {
-	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/account.json",
+	"$id": "https://github.com/icpc/ccs-specs/raw/2023-06/json-schema/account.json",
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API - account",
 	"description": "Definition of a single account object",

--- a/json-schema/accounts.json
+++ b/json-schema/accounts.json
@@ -1,6 +1,6 @@
 {
 	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/accounts.json",
-	"$schema": "http://json-schema.org/draft/2020-12/schema",
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: accounts",
 	"description": "JSON response of this API call",
 

--- a/json-schema/accounts.json
+++ b/json-schema/accounts.json
@@ -1,5 +1,5 @@
 {
-	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/accounts.json",
+	"$id": "https://github.com/icpc/ccs-specs/raw/2023-06/json-schema/accounts.json",
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: accounts",
 	"description": "JSON response of this API call",

--- a/json-schema/api_information.json
+++ b/json-schema/api_information.json
@@ -1,6 +1,6 @@
 {
 	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/api_information.json",
-	"$schema": "http://json-schema.org/draft/2020-12/schema",
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: API information",
 	"description": "JSON response of this API call",
 

--- a/json-schema/api_information.json
+++ b/json-schema/api_information.json
@@ -1,5 +1,5 @@
 {
-	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/api_information.json",
+	"$id": "https://github.com/icpc/ccs-specs/raw/2023-06/json-schema/api_information.json",
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: API information",
 	"description": "JSON response of this API call",

--- a/json-schema/award.json
+++ b/json-schema/award.json
@@ -1,5 +1,5 @@
 {
-	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/award.json",
+	"$id": "https://github.com/icpc/ccs-specs/raw/2023-06/json-schema/award.json",
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API - award",
 	"description": "Definition of a single award object",

--- a/json-schema/award.json
+++ b/json-schema/award.json
@@ -8,8 +8,8 @@
 	"properties": {
 		"id": { "$ref": "common.json#/identifier" },
 		"citation": { "type": "string" },
-		"team_ids": { "$ref": "common.json#/identifiers" }
+		"team_ids": { "$ref": "common.json#/identifiersornull" }
 	},
-	"required": ["id", "citation", "team_ids"],
+	"required": ["id", "citation"],
 	"$comment": "ANCHOR_TO_INSERT_REQUIRE_STRICT_PROPERTIES"
 }

--- a/json-schema/award.json
+++ b/json-schema/award.json
@@ -1,6 +1,6 @@
 {
 	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/award.json",
-	"$schema": "http://json-schema.org/draft/2020-12/schema",
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API - award",
 	"description": "Definition of a single award object",
 

--- a/json-schema/awards.json
+++ b/json-schema/awards.json
@@ -1,6 +1,6 @@
 {
 	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/awards.json",
-	"$schema": "http://json-schema.org/draft/2020-12/schema",
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: awards",
 	"description": "JSON response of this API call",
 

--- a/json-schema/awards.json
+++ b/json-schema/awards.json
@@ -1,5 +1,5 @@
 {
-	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/awards.json",
+	"$id": "https://github.com/icpc/ccs-specs/raw/2023-06/json-schema/awards.json",
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: awards",
 	"description": "JSON response of this API call",

--- a/json-schema/clarification.json
+++ b/json-schema/clarification.json
@@ -1,6 +1,6 @@
 {
 	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/clarification.json",
-	"$schema": "http://json-schema.org/draft/2020-12/schema",
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API - clarification",
 	"description": "Definition of a single clarification object",
 

--- a/json-schema/clarification.json
+++ b/json-schema/clarification.json
@@ -1,5 +1,5 @@
 {
-	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/clarification.json",
+	"$id": "https://github.com/icpc/ccs-specs/raw/2023-06/json-schema/clarification.json",
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API - clarification",
 	"description": "Definition of a single clarification object",

--- a/json-schema/clarifications.json
+++ b/json-schema/clarifications.json
@@ -1,5 +1,5 @@
 {
-	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/clarifications.json",
+	"$id": "https://github.com/icpc/ccs-specs/raw/2023-06/json-schema/clarifications.json",
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: clarifications",
 	"description": "JSON response of this API call",

--- a/json-schema/clarifications.json
+++ b/json-schema/clarifications.json
@@ -1,6 +1,6 @@
 {
 	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/clarifications.json",
-	"$schema": "http://json-schema.org/draft/2020-12/schema",
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: clarifications",
 	"description": "JSON response of this API call",
 

--- a/json-schema/commentaries.json
+++ b/json-schema/commentaries.json
@@ -1,5 +1,5 @@
 {
-	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/commentaries.json",
+	"$id": "https://github.com/icpc/ccs-specs/raw/2023-06/json-schema/commentaries.json",
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: commentary",
 	"description": "JSON response of this API call",

--- a/json-schema/commentaries.json
+++ b/json-schema/commentaries.json
@@ -1,6 +1,6 @@
 {
 	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/commentaries.json",
-	"$schema": "http://json-schema.org/draft/2020-12/schema",
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: commentary",
 	"description": "JSON response of this API call",
 

--- a/json-schema/commentary.json
+++ b/json-schema/commentary.json
@@ -1,5 +1,5 @@
 {
-	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/commentary.json",
+	"$id": "https://github.com/icpc/ccs-specs/raw/2023-06/json-schema/commentary.json",
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API - commentary",
 	"description": "Definition of a single commentary object",

--- a/json-schema/commentary.json
+++ b/json-schema/commentary.json
@@ -10,9 +10,16 @@
 		"time": { "$ref": "common.json#/abstime" },
 		"contest_time": { "$ref": "common.json#/reltime" },
 		"message": { "type": "string" },
+		"tags": {
+			"type": "array",
+			"uniqueItems": true,
+			"items": { "type": "string" }
+		},
+		"source_id": { "$ref": "common.json#/identifierornull" },
 		"team_ids": { "$ref": "common.json#/identifiersornull" },
-		"problem_ids": { "$ref": "common.json#/identifiersornull" }
+		"problem_ids": { "$ref": "common.json#/identifiersornull" },
+		"submission_ids": { "$ref": "common.json#/identifiersornull" }
 	},
-	"required": ["id", "time", "contest_time", "message", "team_ids", "problem_ids"],
+	"required": ["id", "time", "contest_time", "message", "tags"],
 	"$comment": "ANCHOR_TO_INSERT_REQUIRE_STRICT_PROPERTIES"
 }

--- a/json-schema/commentary.json
+++ b/json-schema/commentary.json
@@ -1,6 +1,6 @@
 {
 	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/commentary.json",
-	"$schema": "http://json-schema.org/draft/2020-12/schema",
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API - commentary",
 	"description": "Definition of a single commentary object",
 

--- a/json-schema/common.json
+++ b/json-schema/common.json
@@ -1,5 +1,5 @@
 {
-	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/common.json",
+	"$id": "https://github.com/icpc/ccs-specs/raw/2023-06/json-schema/common.json",
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API - common definitions",
 	"description": "Common definitions of objects used in the API calls",

--- a/json-schema/common.json
+++ b/json-schema/common.json
@@ -1,6 +1,6 @@
 {
 	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/common.json",
-	"$schema": "http://json-schema.org/draft/2020-12/schema",
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API - common definitions",
 	"description": "Common definitions of objects used in the API calls",
 

--- a/json-schema/common.json
+++ b/json-schema/common.json
@@ -143,9 +143,9 @@
 		"type": "object",
 		"properties": {
 			"href":     { "type": "string" },
-			"mime":     { "type": "string" },
-			"hash":     { "type": "string" },
 			"filename": { "type": "string" },
+			"hash":     { "type": "string" },
+			"mime":     { "type": "string" },
 			"width":    { "type": "integer", "minimum": 1 },
 			"height":   { "type": "integer", "minimum": 1 }
 		},

--- a/json-schema/contest.json
+++ b/json-schema/contest.json
@@ -1,6 +1,6 @@
 {
 	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/contest.json",
-	"$schema": "http://json-schema.org/draft/2020-12/schema",
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: contest",
 	"description": "JSON response of this API call",
 

--- a/json-schema/contest.json
+++ b/json-schema/contest.json
@@ -1,5 +1,5 @@
 {
-	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/contest.json",
+	"$id": "https://github.com/icpc/ccs-specs/raw/2023-06/json-schema/contest.json",
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: contest",
 	"description": "JSON response of this API call",

--- a/json-schema/contests.json
+++ b/json-schema/contests.json
@@ -1,5 +1,5 @@
 {
-	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/contests.json",
+	"$id": "https://github.com/icpc/ccs-specs/raw/2023-06/json-schema/contests.json",
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: contests",
 	"description": "JSON response of this API call",

--- a/json-schema/contests.json
+++ b/json-schema/contests.json
@@ -1,6 +1,6 @@
 {
 	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/contests.json",
-	"$schema": "http://json-schema.org/draft/2020-12/schema",
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: contests",
 	"description": "JSON response of this API call",
 

--- a/json-schema/event-feed-array.json
+++ b/json-schema/event-feed-array.json
@@ -1,6 +1,6 @@
 {
 	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/event-feed-array.json",
-	"$schema": "http://json-schema.org/draft/2020-12/schema",
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: event-feed array",
 	"description": "JSON array of responses of this NDJSON API call",
 

--- a/json-schema/event-feed-array.json
+++ b/json-schema/event-feed-array.json
@@ -1,5 +1,5 @@
 {
-	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/event-feed-array.json",
+	"$id": "https://github.com/icpc/ccs-specs/raw/2023-06/json-schema/event-feed-array.json",
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: event-feed array",
 	"description": "JSON array of responses of this NDJSON API call",

--- a/json-schema/event-feed.json
+++ b/json-schema/event-feed.json
@@ -1,6 +1,6 @@
 {
 	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/event-feed.json",
-	"$schema": "http://json-schema.org/draft/2020-12/schema",
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: event-feed",
 	"description": "Single line response of this NDJSON API call",
 

--- a/json-schema/event-feed.json
+++ b/json-schema/event-feed.json
@@ -1,5 +1,5 @@
 {
-	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/event-feed.json",
+	"$id": "https://github.com/icpc/ccs-specs/raw/2023-06/json-schema/event-feed.json",
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: event-feed",
 	"description": "Single line response of this NDJSON API call",

--- a/json-schema/group.json
+++ b/json-schema/group.json
@@ -1,6 +1,6 @@
 {
 	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/group.json",
-	"$schema": "http://json-schema.org/draft/2020-12/schema",
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API - group",
 	"description": "Definition of a single group object",
 

--- a/json-schema/group.json
+++ b/json-schema/group.json
@@ -1,5 +1,5 @@
 {
-	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/group.json",
+	"$id": "https://github.com/icpc/ccs-specs/raw/2023-06/json-schema/group.json",
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API - group",
 	"description": "Definition of a single group object",

--- a/json-schema/groups.json
+++ b/json-schema/groups.json
@@ -1,6 +1,6 @@
 {
 	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/groups.json",
-	"$schema": "http://json-schema.org/draft/2020-12/schema",
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: groups",
 	"description": "JSON response of this API call",
 

--- a/json-schema/groups.json
+++ b/json-schema/groups.json
@@ -1,5 +1,5 @@
 {
-	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/groups.json",
+	"$id": "https://github.com/icpc/ccs-specs/raw/2023-06/json-schema/groups.json",
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: groups",
 	"description": "JSON response of this API call",

--- a/json-schema/judgement-type.json
+++ b/json-schema/judgement-type.json
@@ -1,6 +1,6 @@
 {
 	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/judgement-type.json",
-	"$schema": "http://json-schema.org/draft/2020-12/schema",
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API - judgement_type",
 	"description": "Definition of a single judgement-type object",
 

--- a/json-schema/judgement-type.json
+++ b/json-schema/judgement-type.json
@@ -1,5 +1,5 @@
 {
-	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/judgement-type.json",
+	"$id": "https://github.com/icpc/ccs-specs/raw/2023-06/json-schema/judgement-type.json",
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API - judgement_type",
 	"description": "Definition of a single judgement-type object",

--- a/json-schema/judgement-types.json
+++ b/json-schema/judgement-types.json
@@ -1,5 +1,5 @@
 {
-	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/judgement-types.json",
+	"$id": "https://github.com/icpc/ccs-specs/raw/2023-06/json-schema/judgement-types.json",
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: judgement_types",
 	"description": "JSON response of this API call",

--- a/json-schema/judgement-types.json
+++ b/json-schema/judgement-types.json
@@ -1,6 +1,6 @@
 {
 	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/judgement-types.json",
-	"$schema": "http://json-schema.org/draft/2020-12/schema",
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: judgement_types",
 	"description": "JSON response of this API call",
 

--- a/json-schema/judgement.json
+++ b/json-schema/judgement.json
@@ -1,5 +1,5 @@
 {
-	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/judgement.json",
+	"$id": "https://github.com/icpc/ccs-specs/raw/2023-06/json-schema/judgement.json",
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API - judgement",
 	"description": "Definition of a single judgement object",

--- a/json-schema/judgement.json
+++ b/json-schema/judgement.json
@@ -1,6 +1,6 @@
 {
 	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/judgement.json",
-	"$schema": "http://json-schema.org/draft/2020-12/schema",
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API - judgement",
 	"description": "Definition of a single judgement object",
 

--- a/json-schema/judgement.json
+++ b/json-schema/judgement.json
@@ -28,6 +28,14 @@
 			]
 		}
 	},
-	"required": ["id", "submission_id", "start_time", "start_contest_time", "end_time", "end_contest_time"],
+	"oneOf": [
+		{
+			"required": ["judgement_type_id", "end_time", "end_contest_time"]
+		},
+		{
+			"not": { "required": ["judgement_type_id", "end_time", "end_contest_time"] }
+		}
+	],
+	"required": ["id", "submission_id", "start_time", "start_contest_time"],
 	"$comment": "ANCHOR_TO_INSERT_REQUIRE_STRICT_PROPERTIES"
 }

--- a/json-schema/judgement.json
+++ b/json-schema/judgement.json
@@ -9,6 +9,10 @@
 		"id": { "$ref": "common.json#/identifier" },
 		"submission_id": { "$ref": "common.json#/identifier" },
 		"judgement_type_id": { "$ref": "common.json#/judgementtypeidornull" },
+		"score": {
+			"type": "number",
+			"minimum": 0
+		},
 		"start_time": { "$ref": "common.json#/abstime" },
 		"start_contest_time": { "$ref": "common.json#/reltime" },
 		"end_time": { "$ref": "common.json#/abstimeornull" },

--- a/json-schema/judgements.json
+++ b/json-schema/judgements.json
@@ -1,5 +1,5 @@
 {
-	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/judgements.json",
+	"$id": "https://github.com/icpc/ccs-specs/raw/2023-06/json-schema/judgements.json",
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: judgements",
 	"description": "JSON response of this API call",

--- a/json-schema/judgements.json
+++ b/json-schema/judgements.json
@@ -1,6 +1,6 @@
 {
 	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/judgements.json",
-	"$schema": "http://json-schema.org/draft/2020-12/schema",
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: judgements",
 	"description": "JSON response of this API call",
 

--- a/json-schema/language.json
+++ b/json-schema/language.json
@@ -1,5 +1,5 @@
 {
-	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/language.json",
+	"$id": "https://github.com/icpc/ccs-specs/raw/2023-06/json-schema/language.json",
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API - language",
 	"description": "Definition of a single language object",

--- a/json-schema/language.json
+++ b/json-schema/language.json
@@ -1,6 +1,6 @@
 {
 	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/language.json",
-	"$schema": "http://json-schema.org/draft/2020-12/schema",
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API - language",
 	"description": "Definition of a single language object",
 

--- a/json-schema/languages.json
+++ b/json-schema/languages.json
@@ -1,5 +1,5 @@
 {
-	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/languages.json",
+	"$id": "https://github.com/icpc/ccs-specs/raw/2023-06/json-schema/languages.json",
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: languages",
 	"description": "JSON response of this API call",

--- a/json-schema/languages.json
+++ b/json-schema/languages.json
@@ -1,6 +1,6 @@
 {
 	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/languages.json",
-	"$schema": "http://json-schema.org/draft/2020-12/schema",
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: languages",
 	"description": "JSON response of this API call",
 

--- a/json-schema/organization.json
+++ b/json-schema/organization.json
@@ -1,5 +1,5 @@
 {
-	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/organization.json",
+	"$id": "https://github.com/icpc/ccs-specs/raw/2023-06/json-schema/organization.json",
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API - organization",
 	"description": "Definition of a single organization object",

--- a/json-schema/organization.json
+++ b/json-schema/organization.json
@@ -1,6 +1,6 @@
 {
 	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/organization.json",
-	"$schema": "http://json-schema.org/draft/2020-12/schema",
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API - organization",
 	"description": "Definition of a single organization object",
 

--- a/json-schema/organizations.json
+++ b/json-schema/organizations.json
@@ -1,6 +1,6 @@
 {
 	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/organizations.json",
-	"$schema": "http://json-schema.org/draft/2020-12/schema",
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: organizations",
 	"description": "JSON response of this API call",
 

--- a/json-schema/organizations.json
+++ b/json-schema/organizations.json
@@ -1,5 +1,5 @@
 {
-	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/organizations.json",
+	"$id": "https://github.com/icpc/ccs-specs/raw/2023-06/json-schema/organizations.json",
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: organizations",
 	"description": "JSON response of this API call",

--- a/json-schema/person.json
+++ b/json-schema/person.json
@@ -1,5 +1,5 @@
 {
-	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/person.json",
+	"$id": "https://github.com/icpc/ccs-specs/raw/2023-06/json-schema/person.json",
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API - person",
 	"description": "Definition of a single person object",

--- a/json-schema/person.json
+++ b/json-schema/person.json
@@ -1,6 +1,6 @@
 {
 	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/person.json",
-	"$schema": "http://json-schema.org/draft/2020-12/schema",
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API - person",
 	"description": "Definition of a single person object",
 

--- a/json-schema/person.json
+++ b/json-schema/person.json
@@ -7,8 +7,8 @@
 	"type": "object",
 	"properties": {
 		"id": { "$ref": "common.json#/identifier" },
-		"team_ids": { "$ref": "common.json#/identifiers" },
 		"icpc_id": { "type": [ "string", "null" ] },
+		"team_ids": { "$ref": "common.json#/identifiers" },
 		"name": { "type": "string" },
 		"title": { "type": [ "string", "null" ] },
 		"email": { "type": [ "string", "null" ] },

--- a/json-schema/persons.json
+++ b/json-schema/persons.json
@@ -1,6 +1,6 @@
 {
 	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/persons.json",
-	"$schema": "http://json-schema.org/draft/2020-12/schema",
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: persons",
 	"description": "JSON response of this API call",
 

--- a/json-schema/persons.json
+++ b/json-schema/persons.json
@@ -1,5 +1,5 @@
 {
-	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/persons.json",
+	"$id": "https://github.com/icpc/ccs-specs/raw/2023-06/json-schema/persons.json",
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: persons",
 	"description": "JSON response of this API call",

--- a/json-schema/problem.json
+++ b/json-schema/problem.json
@@ -1,5 +1,5 @@
 {
-	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/problem.json",
+	"$id": "https://github.com/icpc/ccs-specs/raw/2023-06/json-schema/problem.json",
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API - problem",
 	"description": "Definition of a single problem object",

--- a/json-schema/problem.json
+++ b/json-schema/problem.json
@@ -1,6 +1,6 @@
 {
 	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/problem.json",
-	"$schema": "http://json-schema.org/draft/2020-12/schema",
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API - problem",
 	"description": "Definition of a single problem object",
 

--- a/json-schema/problems.json
+++ b/json-schema/problems.json
@@ -1,6 +1,6 @@
 {
 	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/problems.json",
-	"$schema": "http://json-schema.org/draft/2020-12/schema",
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: problems",
 	"description": "JSON response of this API call",
 

--- a/json-schema/problems.json
+++ b/json-schema/problems.json
@@ -1,5 +1,5 @@
 {
-	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/problems.json",
+	"$id": "https://github.com/icpc/ccs-specs/raw/2023-06/json-schema/problems.json",
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: problems",
 	"description": "JSON response of this API call",

--- a/json-schema/run.json
+++ b/json-schema/run.json
@@ -1,5 +1,5 @@
 {
-	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/run.json",
+	"$id": "https://github.com/icpc/ccs-specs/raw/2023-06/json-schema/run.json",
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API - run",
 	"description": "Definition of a single run object",

--- a/json-schema/run.json
+++ b/json-schema/run.json
@@ -1,6 +1,6 @@
 {
 	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/run.json",
-	"$schema": "http://json-schema.org/draft/2020-12/schema",
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API - run",
 	"description": "Definition of a single run object",
 

--- a/json-schema/runs.json
+++ b/json-schema/runs.json
@@ -1,5 +1,5 @@
 {
-	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/runs.json",
+	"$id": "https://github.com/icpc/ccs-specs/raw/2023-06/json-schema/runs.json",
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: runs",
 	"description": "JSON response of this API call",

--- a/json-schema/runs.json
+++ b/json-schema/runs.json
@@ -1,6 +1,6 @@
 {
 	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/runs.json",
-	"$schema": "http://json-schema.org/draft/2020-12/schema",
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: runs",
 	"description": "JSON response of this API call",
 

--- a/json-schema/scoreboard.json
+++ b/json-schema/scoreboard.json
@@ -1,5 +1,5 @@
 {
-	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/scoreboard.json",
+	"$id": "https://github.com/icpc/ccs-specs/raw/2023-06/json-schema/scoreboard.json",
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: scoreboard",
 	"description": "JSON response of this API call",

--- a/json-schema/scoreboard.json
+++ b/json-schema/scoreboard.json
@@ -1,6 +1,6 @@
 {
 	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/scoreboard.json",
-	"$schema": "http://json-schema.org/draft/2020-12/schema",
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: scoreboard",
 	"description": "JSON response of this API call",
 

--- a/json-schema/state.json
+++ b/json-schema/state.json
@@ -7,8 +7,8 @@
 	"type": "object",
 	"properties": {
 		"started":        { "$ref": "common.json#/abstimeornull" },
-		"ended":          { "$ref": "common.json#/abstimeornull" },
 		"frozen":         { "$ref": "common.json#/abstimeornull" },
+		"ended":          { "$ref": "common.json#/abstimeornull" },
 		"thawed":         { "$ref": "common.json#/abstimeornull" },
 		"finalized":      { "$ref": "common.json#/abstimeornull" },
 		"end_of_updates": { "$ref": "common.json#/abstimeornull" }

--- a/json-schema/state.json
+++ b/json-schema/state.json
@@ -1,6 +1,6 @@
 {
 	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/state.json",
-	"$schema": "http://json-schema.org/draft/2020-12/schema",
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: state",
 	"description": "JSON response of this API call",
 

--- a/json-schema/state.json
+++ b/json-schema/state.json
@@ -1,5 +1,5 @@
 {
-	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/state.json",
+	"$id": "https://github.com/icpc/ccs-specs/raw/2023-06/json-schema/state.json",
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: state",
 	"description": "JSON response of this API call",

--- a/json-schema/submission.json
+++ b/json-schema/submission.json
@@ -1,5 +1,5 @@
 {
-	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/submission.json",
+	"$id": "https://github.com/icpc/ccs-specs/raw/2023-06/json-schema/submission.json",
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API - submission",
 	"description": "Definition of a single submission object",

--- a/json-schema/submission.json
+++ b/json-schema/submission.json
@@ -1,6 +1,6 @@
 {
 	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/submission.json",
-	"$schema": "http://json-schema.org/draft/2020-12/schema",
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API - submission",
 	"description": "Definition of a single submission object",
 

--- a/json-schema/submissions.json
+++ b/json-schema/submissions.json
@@ -1,5 +1,5 @@
 {
-	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/submissions.json",
+	"$id": "https://github.com/icpc/ccs-specs/raw/2023-06/json-schema/submissions.json",
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: submissions",
 	"description": "JSON response of this API call",

--- a/json-schema/submissions.json
+++ b/json-schema/submissions.json
@@ -1,6 +1,6 @@
 {
 	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/submissions.json",
-	"$schema": "http://json-schema.org/draft/2020-12/schema",
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: submissions",
 	"description": "JSON response of this API call",
 

--- a/json-schema/team.json
+++ b/json-schema/team.json
@@ -1,5 +1,5 @@
 {
-	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/team.json",
+	"$id": "https://github.com/icpc/ccs-specs/raw/2023-06/json-schema/team.json",
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API - team",
 	"description": "Definition of a single team object",

--- a/json-schema/team.json
+++ b/json-schema/team.json
@@ -1,6 +1,6 @@
 {
 	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/team.json",
-	"$schema": "http://json-schema.org/draft/2020-12/schema",
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API - team",
 	"description": "Definition of a single team object",
 

--- a/json-schema/teams.json
+++ b/json-schema/teams.json
@@ -1,6 +1,6 @@
 {
 	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/teams.json",
-	"$schema": "http://json-schema.org/draft/2020-12/schema",
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: teams",
 	"description": "JSON response of this API call",
 

--- a/json-schema/teams.json
+++ b/json-schema/teams.json
@@ -1,5 +1,5 @@
 {
-	"$id": "https://github.com/icpc/ccs-specs/raw/master/json-schema/teams.json",
+	"$id": "https://github.com/icpc/ccs-specs/raw/2023-06/json-schema/teams.json",
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"title": "CLICS Contest API: teams",
 	"description": "JSON response of this API call",


### PR DESCRIPTION
This contains the relevant cherry-picks from https://github.com/icpc/ccs-specs/pull/194 and renames the schema `$id` property to the `2023-06` branch.