### PR TITLE
Specify explicitly that nullable IDs can be filtered on

### DIFF
--- a/Contest_API.md
+++ b/Contest_API.md
@@ -588,8 +588,9 @@ Note that all results returned from endpoints:
 ### Filtering
 
 Endpoints that return a JSON array must allow filtering on any
-property with type ID (except the `id` property) by passing it as a
-query argument. For example, clarifications can be filtered on the
+property specified in the [Access](#access) endpoint with type `ID` or
+`ID ?` (except the `id` property) by passing it as a query argument.
+For example, clarifications can be filtered on the
 recipient by passing `to_team_id=X`. To filter on a `null` value,
 pass an empty string, i.e. `to_team_id=`. It must be possible to
 filter on multiple different properties simultaneously, with the


### PR DESCRIPTION
Also explicitly mention that filtering only needs to be supported on properties listed in the access endpoint.

Adresses the "on a related note" in https://github.com/icpc/ccs-specs/pull/193#discussion_r1938694646