### PR TITLE
Clarify maximum score for problems

### DIFF
--- a/Contest_API.md
+++ b/Contest_API.md
@@ -1133,7 +1133,7 @@ Properties of problem objects:
 | output\_limit     | integer   | Limit in MiB on what the submission can write both to `stdout` and `stderr`. If a submission produces more output, a CCS should fail the submission or ignore output beyond this limit.
 | code\_limit       | integer   | Limit in KiB on submissions for this problem. Submissions that are larger should be rejected by a CCS.
 | test\_data\_count | integer   | Number of test data sets.
-| max\_score        | number    | Maximum expected score, although teams may score higher in some cases. Typically used to indicate scoreboard cell color in scoring contests. Required iff contest:scoreboard\_type is `score`.
+| max\_score        | number    | Maximum score. Typically used to determine scoreboard cell color. Required iff contest:scoreboard\_type is `score`.
 | package           | array of FILE ? | [Problem package](https://www.kattis.com/problem-package-format/). Expected mime type is application/zip. Only exactly one package is allowed. Not expected to actually contain href for package during the contest, but used for configuration and archiving.
 | statement         | array of FILE ? | Problem statement. Expected mime type is application/pdf. 
 


### PR DESCRIPTION
This PR was started because we noticed that the problem format allows both -infinity and +infinity as maximum scores, but the Contest API doesn't allow either. After talking to Fredrik and Nicky we decided not to 'fix' this:
- -infinity is being removed from the next version of the problem format.
- +infinity is rarely used, and there's an easy workaround (just pick an arbitrarily high value) so we'll leave it.

While discussing this we found that the max_score was poorly defined as 'this is the max, but maybe not' and decided to simplify and make it more strict. I went with just removing the weak phrase: this IS the maximum score possible.

I also felt 'indicate' could be improved (went with 'determine') and 'in scoring contests' was redundant (removed it).

As with anything in the spec, we'd expect servers to enforce the max_score, but encourage clients to be liberal in what they accept. e.g. currently the resolver doesn't work if you score the maximum and then have another submission, but we'll fix this.