### PR TITLE
Simplified judgement types

### DIFF
--- a/Contest_API.md
+++ b/Contest_API.md
@@ -912,7 +912,7 @@ Properties of judgement type objects:
 | name                            | string    | Name of the judgement. (might not match table below, e.g. if localized).
 | penalty                         | boolean   | Whether this judgement causes penalty time. Required iff contest:penalty\_time is present.
 | solved                          | boolean   | Whether this judgement is considered correct.
-| simplified\_judgement\_type\_id | ID?       | Identifier of this type's simplified judgement type. When using simplified judgements, this is required iff simplified\_only is false.
+| simplified\_judgement\_type\_id | ID?       | Identifier of this type's simplified judgement type.
 
 #### Known judgement types
 
@@ -1041,7 +1041,6 @@ Returned data:
    "penalty": false,
    "solved": true,
    "simplified_judgement_type_id": "AC"
-   "simplified_only": false
 }
 ```
 


### PR DESCRIPTION
Adds an optional simplified judgement type id to judgement types. These would be specified in cases where (e.g.) a team should not see the specific judgement that another team received.

The length of the property is unfortunate, but follows the naming pattern elsewhere.

** This is the first half of this change - judgements may need to be modified as well. We will not release a new version of the spec until we complete the second change or back this one out.