### PR TITLE
Broadcast clarification responses

### DIFF
--- a/Contest_API.md
+++ b/Contest_API.md
@@ -1820,6 +1820,9 @@ Properties of clarification message objects:
 
 The recipients of a clarification are the union of `to_team_ids` and `to_group_ids`.  A clarification is sent to all teams if `from_team_id`, `to_team_ids` and `to_group_ids` are null.  Note that if `from_team_id` is not `null`, then both `to_team_ids` and `to_group_ids` must be `null`. That is, teams cannot send messages to other teams or groups.
 
+Clarifications between a team and the jury are typically private. If the jury responds with a broadcast to all teams, the
+reply_to_id should be removed for everyone who couldn't see the original message in order to preserve referrential integrity.
+
 #### Modifying clarifications
 
 To add a clarification, clients can use the `POST` method on the clarifications endpoint or the

--- a/Contest_Control_System_Requirements.md
+++ b/Contest_Control_System_Requirements.md
@@ -640,7 +640,10 @@ following operations:
 - Determine, for any specific clarification request, what answer was returned to
   the team if the clar has already been answered.
 - Compose an answer to the clar and send it, along with the text of the original
-  clarification request, to the team.
+  clarification request, to the team. The best practice is to include the
+  original clarification text as an internet-style response, which allows the judge
+  to respond to multiple points or edit it, and doesn't require the original
+  clarification text to understand the response.
 - Optionally choose to also send the clarification request text and answer to
   all teams in the contest.
 - Change the category of a clarification request.


### PR DESCRIPTION
Adds a comment to the Contest API about keeping referential integrity when the jury responds to a private message with a broadcast. (Corresponding CDS issue #1224 opened in ICPC tools repo)

Adds a comment to the CCS requirement indicating best practice is to use internet-style responses.

Fixes #221.