### PR TITLE
Be more explicit about what to POST for submission file

### DIFF
--- a/Contest_API.md
+++ b/Contest_API.md
@@ -1689,7 +1689,7 @@ Request data:
    "team_id":"123",
    "time":"2014-06-25T11:22:05.034+01",
    "entry_point":"Main",
-   "files":[{"data": "<base64 string>"}]
+   "files":[{"data": "<base64 encoded zip file>"}]
 }
 ```
 


### PR DESCRIPTION
When @johnbrvc implemented the PC^2 submit client, which is supposed to be CLICS compliant, he made it create a array of files, where each file is base64 encoded and represents one file in the original submission.

But as far as I know, we expect a base64 encoded ZIP file with all submission source files in it.

This just improves the sample a small bit to make this a bit more clear.