### PR TITLE
Optional team_id and account_id for submissions

### DIFF
--- a/Contest_API.md
+++ b/Contest_API.md
@@ -1578,7 +1578,7 @@ Properties of submission objects:
 | id            | ID              | Identifier of the submission. Usable as a label, typically a low incrementing number to make it easier to validate submissions or compare submissions with a Shadow CCS.
 | language\_id  | ID              | Identifier of the [language](#languages) submitted for.
 | problem\_id   | ID              | Identifier of the [problem](#problems) submitted for.
-| team\_id      | ID ?            | Identifier of the [team](#teams) that made the submission.
+| team\_id      | ID ?            | Identifier of the [team](#teams) that made the submission. Submissions without a `team_id` cannot affect the scoreboard.
 | account\_id   | ID ?            | Identifier of the [account](#account) that made the submission.
 | time          | TIME            | Timestamp of when the submission was made.
 | contest\_time | RELTIME         | Contest relative time when the submission was made.


### PR DESCRIPTION
Some CCSs allow judges or other non-team accounts to make submissions, e.g. to test the judging system or problem solutions prior to the start of a contest. This allows team_id to be null for these situations, and adds an optional account_id to indicate which account was used to make a submission.

I struggled if we should add more detail or say things like 'team_id is required iff submitted by a team', but these seemed weak and inconsistent with what we've done elsewhere. Let me know if you think we should add anything.

First part of #230.