### PR TITLE
Include event-feed.ndjson in Results upload

### DIFF
--- a/Contest_Package.md
+++ b/Contest_Package.md
@@ -242,10 +242,10 @@ Required files:
 - [api](json_format#api-information) (`api.json`)
 - [teams](json_format#teams) (`teams.json`)
 - [scoreboard](json_format#scoreboard) (`scoreboard.json`)
-- [event-feed](json_format#notification-object) (`event-feed.ndjson`)
 
 Optional files:
 - [awards](json_format#awards) (`awards.json`)
+- [event-feed](json_format#notification-object) (`event-feed.ndjson`)
 
 #### Example file listing
 

--- a/Contest_Package.md
+++ b/Contest_Package.md
@@ -242,6 +242,7 @@ Required files:
 - [api](json_format#api-information) (`api.json`)
 - [teams](json_format#teams) (`teams.json`)
 - [scoreboard](json_format#scoreboard) (`scoreboard.json`)
+- [event-feed](json_format#notification-object) (`event-feed.ndjson`)
 
 Optional files:
 - [awards](json_format#awards) (`awards.json`)
@@ -254,6 +255,7 @@ api/logo.png
 teams.json
 scoreboard.json
 awards.json
+event-feed.ndjson
 ```
 
 ## Example YAML files


### PR DESCRIPTION
Add event-feed.ndjson to required and optional files of the Results upload.