### PR TITLE
Allow persons to have multiple roles

### DIFF
--- a/JSON_Format.md
+++ b/JSON_Format.md
@@ -848,7 +848,7 @@ Properties of an account object:
 | username          | string    | The account username.
 | password          | string ?  | The account password.
 | name              | string ?  | The name of the account.
-| type              | string    | The type of account, e.g. `team`, `judge`, `admin`, `analyst`, `staff`.
+| type              | string    | The type of account, e.g. `team`, `coach`, `judge`, `admin`, `analyst`, `staff`.
 | ip                | string ?  | IP address associated with this account, used for auto-login.
 | team\_id          | ID ?      | The team that this account is for. Required iff type is `team`.
 | person\_id        | ID ?      | The person that this account is for, if the account is only for one person.
@@ -860,7 +860,8 @@ expected that non-admin clients never see passwords, and typically do not see ac
 
 ```json
 [{"id":"stephan","username":"stephan","name":"Stephan's home account","type":"judge","ip":"10.0.0.1"},
- {"id":"team45","username":"team45","type":"team","ip":"10.1.1.45","team_id":"45"}
+ {"id":"team45","username":"team45","type":"team","ip":"10.1.1.45","team_id":"45"},
+ {"id":"coach45","username":"coach45","type":"coach"}
 ]
 ```
 

--- a/JSON_Format.md
+++ b/JSON_Format.md
@@ -804,20 +804,31 @@ Properties of a person object:
 | :---------- | :-------------- | :----------
 | id          | ID              | Identifier of the person.
 | icpc\_id    | string ?        | External identifier from ICPC CMS.
-| team\_ids   | array of ID ?   | [Team](#team) of this person. Required to be non-empty iff role is `contestant` or `coach`.
 | name        | string          | Name of the person.
-| title       | string ?        | Title of the person, e.g. "Technical director".
 | email       | string ?        | Email of the person.
 | sex         | string ?        | Either `male` or `female`, or possibly `null`.
-| role        | string          | One of `contestant`, `coach`, `staff`, or `other`.
+| roles       | array of ROLE   | Roles of this person in the contest. Must not be empty.
 | photo       | array of FILE ? | Registration photo of the person. Only allowed mime types are image/\*.
+
+Properties of role objects (ROLE):
+
+| Name        | Type     | Description
+| :---------- | :------- | :----------
+| type        | string   | One of `contestant`, `coach`, `staff`, or `other`.
+| title       | string ? | Title for this role, e.g. "Co-Coach" or "Technical director".
+| team\_id    | ID ?     | [Team](#teams) this role applies to. Required iff `type` is `contestant` or `coach`.
 
 #### Examples
 
 ```json
-[{"id":"john-smith","team_ids":["43"],"icpc_id":"32442","name":"John Smith","email":"john.smith@kmail.com","sex":"male","role":"contestant"},
- {"id":"osten-umlautsen","team_ids":["43","44"],"icpc_id":null,"name":"Östen Ümlautsen","sex":null,"role":"coach"},
- {"id":"bill","name":"Bill Farrell","sex":"male","title":"Executive Director","role":"staff"}
+[{"id":"john-smith","icpc_id":"32442","name":"John Smith","email":"john.smith@kmail.com","sex":"male",
+  "roles":[{"type":"contestant","team_id":"43"}]},
+ {"id":"osten-umlautsen","icpc_id":null,"name":"Östen Ümlautsen","sex":null,
+  "roles":[{"type":"coach","team_id":"43"},{"type":"coach","title":"Co-Coach","team_id":"44"}]},
+ {"id":"bill","name":"Bill Farrell","sex":"male",
+  "roles":[{"type":"staff","title":"Executive Director"}]},
+ {"id":"jane-doe","name":"Jane Doe",
+  "roles":[{"type":"coach","team_id":"44"},{"type":"staff"}]}
 ]
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -40,6 +40,10 @@ This is the draft of some future version of the CCS specification.
   accordingly.
 - Added `score` field to [runs](json_format#runs) for scoring contests,
   with a note that per-run scores are not well-defined for most problems.
+- Restructured the `role` field on [persons](json_format#persons) into a
+  `roles` array of objects, each with a `type`, optional `title`, and
+  optional `team_id`, to support persons with multiple roles.
+- Added `coach` as a supported [account](json_format#accounts) type.
 
 ## References
 


### PR DESCRIPTION
Closes #245 

Implements the fix discussed in the issue. Also adds `coach` to account types.
