### PR TITLE
Add shirt color to team

### DIFF
--- a/JSON_Format.md
+++ b/JSON_Format.md
@@ -779,6 +779,10 @@ Properties of a team object:
 | desktop          | array of FILE ?        | Streaming video of the team desktop. Only allowed mime types are video/\* or application/vnd.apple.mpegurl.
 | webcam           | array of FILE ?        | Streaming video of the team webcam. Only allowed mime types are video/\* or application/vnd.apple.mpegurl.
 | audio            | array of FILE ?        | Streaming team audio.
+| shirt\_rgb       | string ?               | Hexadecimal RGB value of the team's t-shirt body color as specified in [HTML hexadecimal colors](https://en.wikipedia.org/wiki/Web_colors#Hex_triplet) with no alpha channel, e.g. `#AC00FF` or `#fff`.
+| shirt\_color     | string ?               | Human readable body color description associated to the RGB value.
+| shirt\_text\_rgb | string ?               | Hexadecimal RGB value of the team's t-shirt text color as specified in [HTML hexadecimal colors](https://en.wikipedia.org/wiki/Web_colors#Hex_triplet) with no alpha channel, e.g. `#AC00FF` or `#fff`.
+| shirt\_text\_color | string ?             | Human readable text color description associated to the RGB value.
 
 Properties of a team location object:
 
@@ -791,7 +795,7 @@ Properties of a team location object:
 #### Examples
 
 ```json
-[{"id":"team11","icpc_id":"201433","label":"11","name":"Shanghai Tigers","organization_id":"inst123","group_ids":["asia-74324325532"]},
+[{"id":"team11","icpc_id":"201433","label":"11","name":"Shanghai Tigers","organization_id":"inst123","group_ids":["asia-74324325532"],"shirt_rgb":"#0033A0","shirt_color":"blue","shirt_text_rgb":"#FFFFFF","shirt_text_color":"white"},
  {"id":"team123","label":"123","name":"CMU1","organization_id":"inst105","group_ids":["8","11"]}
 ]
 ```

--- a/JSON_Format.md
+++ b/JSON_Format.md
@@ -779,10 +779,10 @@ Properties of a team object:
 | desktop          | array of FILE ?        | Streaming video of the team desktop. Only allowed mime types are video/\* or application/vnd.apple.mpegurl.
 | webcam           | array of FILE ?        | Streaming video of the team webcam. Only allowed mime types are video/\* or application/vnd.apple.mpegurl.
 | audio            | array of FILE ?        | Streaming team audio.
-| shirt\_rgb       | string ?               | Hexadecimal RGB value of the team's t-shirt body color as specified in [HTML hexadecimal colors](https://en.wikipedia.org/wiki/Web_colors#Hex_triplet) with no alpha channel, e.g. `#AC00FF` or `#fff`.
-| shirt\_color     | string ?               | Human readable body color description associated to the RGB value.
-| shirt\_text\_rgb | string ?               | Hexadecimal RGB value of the team's t-shirt text color as specified in [HTML hexadecimal colors](https://en.wikipedia.org/wiki/Web_colors#Hex_triplet) with no alpha channel, e.g. `#AC00FF` or `#fff`.
-| shirt\_text\_color | string ?             | Human readable text color description associated to the RGB value.
+| primary\_rgb     | string ?               | Hexadecimal RGB value of the team's primary color as specified in [HTML hexadecimal colors](https://en.wikipedia.org/wiki/Web_colors#Hex_triplet) with no alpha channel, e.g. `#AC00FF` or `#fff`.
+| primary\_color   | string ?               | Human readable body color description associated to the RGB value.
+| secondary\_rgb   | string ?               | Hexadecimal RGB value of the team's secondary color as specified in [HTML hexadecimal colors](https://en.wikipedia.org/wiki/Web_colors#Hex_triplet) with no alpha channel, e.g. `#AC00FF` or `#fff`.
+| secondary\_color | string ?               | Human readable text color description associated to the RGB value.
 
 Properties of a team location object:
 
@@ -795,7 +795,7 @@ Properties of a team location object:
 #### Examples
 
 ```json
-[{"id":"team11","icpc_id":"201433","label":"11","name":"Shanghai Tigers","organization_id":"inst123","group_ids":["asia-74324325532"],"shirt_rgb":"#0033A0","shirt_color":"blue","shirt_text_rgb":"#FFFFFF","shirt_text_color":"white"},
+[{"id":"team11","icpc_id":"201433","label":"11","name":"Shanghai Tigers","organization_id":"inst123","group_ids":["asia-74324325532"],"primary_rgb":"#0033A0","primary_color":"blue","secondary_rgb":"#FFFFFF","secondary_color":"white"},
  {"id":"team123","label":"123","name":"CMU1","organization_id":"inst105","group_ids":["8","11"]}
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ This is the draft of some future version of the CCS specification.
   [runs](json_format#runs), as these values are not meaningful for scoring
   and would require unnecessary resending of objects when removed intervals
   change.
-- Added `shirt_rgb`, `shirt_color`, `shirt_text_rgb`, and `shirt_text_color`
+- Added `primary_rgb`, `primary_color`, `secondary_rgb`, and `secondary_color`
   fields to [teams](json_format#teams) for t-shirt color information.
 
 ## References

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ This is the draft of some future version of the CCS specification.
   [runs](json_format#runs), as these values are not meaningful for scoring
   and would require unnecessary resending of objects when removed intervals
   change.
+- Added `shirt_rgb`, `shirt_color`, `shirt_text_rgb`, and `shirt_text_color`
+  fields to [teams](json_format#teams) for t-shirt color information.
 
 ## References
 


### PR DESCRIPTION
Closes #234

- Add a main/body color, as well as a secondary/text color. Both RGB and human readable text name (as with problem color).
