### PR TITLE
Soft best practice on ordering, and add known file tags

### DIFF
--- a/JSON_Format.md
+++ b/JSON_Format.md
@@ -116,8 +116,6 @@ Known values of tags include:
 
 An image should list both values if it is suitable for multiple contexts.
 
-As a best practice, servers should list file references in order from most to least generally applicable, so that clients that do not process tags can pick the first and get a reasonable result.
-
 #### Examples
 
 ```json

--- a/JSON_Format.md
+++ b/JSON_Format.md
@@ -111,8 +111,12 @@ Known values of tags include:
 
 - `light`: an image suitable for use on white or light backgrounds.
 - `dark`: an image suitable for use on black or dark backgrounds.
+- `desktop`: a screenshot or capture of a team's desktop.
+- `webcam`: a capture from a team's webcam.
 
 An image should list both values if it is suitable for multiple contexts.
+
+As a best practice, servers should list file references in order from most to least generally applicable, so that clients that do not process tags can pick the first and get a reasonable result.
 
 #### Examples
 

--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,9 @@ This is the draft of some future version of the CCS specification.
   `roles` array of objects, each with a `type`, optional `title`, and
   optional `team_id`, to support persons with multiple roles.
 - Added `coach` as a supported [account](json_format#accounts) type.
+- Added `desktop` and `webcam` as known [file reference](json_format#file-reference)
+  tags, and added a best practice recommendation for ordering file references
+  from most to least generally applicable.
 
 ## References
 

--- a/readme.md
+++ b/readme.md
@@ -45,8 +45,7 @@ This is the draft of some future version of the CCS specification.
   optional `team_id`, to support persons with multiple roles.
 - Added `coach` as a supported [account](json_format#accounts) type.
 - Added `desktop` and `webcam` as known [file reference](json_format#file-reference)
-  tags, and added a best practice recommendation for ordering file references
-  from most to least generally applicable.
+  tags.
 
 ## References
 


### PR DESCRIPTION
Closes #232 

- Adding a soft best practice of listing "most generally applicable" option first.
- Adding `desktop`, and `webcam` to list of known tags.
