### PR TITLE
Allow sharing output, feedback, and diff per run

### DIFF
--- a/JSON_Format.md
+++ b/JSON_Format.md
@@ -1031,6 +1031,9 @@ Properties of a run object:
 | time                | TIME    | Absolute time when run completed.
 | run\_time           | number  | Run time in seconds. Should be a non-negative integer multiple of `0.001`. The reason for this is to not have rounding ambiguities while still using the natural unit of seconds.
 | score               | number ?| Score for this run. Only applicable when contest:scoreboard\_type is `score`. The meaning of this score is problem dependent; do not assume the final submission score is the minimum, maximum, or sum of the run scores. Note that a per-run score is not well-defined for most runs of most problems. Servers should omit `score` when it is not meaningful for the given problem.
+| team\_output        | array of FILE ? | The output produced by the team's submission for this run.
+| judge\_message      | array of FILE ? | The feedback message produced by the output validator for this run.
+| diff                | array of FILE ? | A diff between the team's output and the judge's answer for this run.
 
 #### Examples
 
@@ -1039,6 +1042,12 @@ Properties of a run object:
   "time":"2014-06-25T11:22:42.420+01","run_time":0.123},
  {"id":"1313","judgement_id":"189550","ordinal":1,"judgement_type_id":"AC",
   "time":"2014-06-25T11:23:10.000+01","run_time":0.456,"score":42.5}
+  "time":"2014-06-25T11:22:42.420+01","run_time":0.123},
+ {"id":"1313","judgement_id":"189550","ordinal":1,"judgement_type_id":"WA",
+  "time":"2014-06-25T11:23:10.000+01","run_time":0.456,
+  "team_output":[{"href":"contests/wf14/runs/1313/team_output","filename":"team_output.txt","mime":"text/plain"}],
+  "judge_message":[{"href":"contests/wf14/runs/1313/judge_message","filename":"judge_message.txt","mime":"text/plain"}],
+  "diff":[{"href":"contests/wf14/runs/1313/diff","filename":"diff.txt","mime":"text/x-diff"}]}
 ]
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -53,6 +53,9 @@ This is the draft of some future version of the CCS specification.
   [runs](json_format#runs), as these values are not meaningful for scoring
   and would require unnecessary resending of objects when removed intervals
   change.
+- Added `team_output`, `judge_message`, and `diff` file reference fields
+  to [runs](json_format#runs), allowing run output and validator feedback
+  to be exposed via the API.
 
 ## References
 


### PR DESCRIPTION
Closes #208 

Adds `team_output`, `judge_message`, and `diff` to runs`.
