### PR TITLE
Update `max_score` when needed

### DIFF
--- a/JSON_Format.md
+++ b/JSON_Format.md
@@ -646,7 +646,7 @@ Properties of a problem object:
 | output\_limit     | integer         | Limit in MiB on what the submission can write both to `stdout` and `stderr`. If a submission produces more output, a CCS should fail the submission or ignore output beyond this limit.
 | code\_limit       | integer         | Limit in KiB on submissions for this problem. Submissions that are larger should be rejected by a CCS.
 | test\_data\_count | integer         | Number of test data sets.
-| max\_score        | number          | Maximum score. Typically used to determine scoreboard cell color. Required iff contest:scoreboard\_type is `score`.
+| max\_score        | number          | Maximum score currently considered achievable for this problem. Used by clients e.g. to shade scoreboard cells relative to the best possible result. Required iff contest:scoreboard\_type is `score`. For problems with a known maximum this value is fixed. For problems where the maximum is not known upfront, this should be set to a reasonable initial target (e.g. 100) and updated during the contest if a submission achieves a higher score.
 | package           | array of FILE ? | [Problem package](https://www.kattis.com/problem-package-format/). Expected mime type is application/zip. Only exactly one package is allowed. Not expected to actually contain href for package during the contest, but used for configuration and archiving.
 | statement         | array of FILE ? | Problem statement. Expected mime type is application/pdf.
 | attachments       | array of FILE ? | Problem attachments. These are files made available to teams other than the problem statement and sample test data. Filenames are expected to match the filename mentioned in the problem statement, if any.

--- a/readme.md
+++ b/readme.md
@@ -53,6 +53,10 @@ This is the draft of some future version of the CCS specification.
   [runs](json_format#runs), as these values are not meaningful for scoring
   and would require unnecessary resending of objects when removed intervals
   change.
+- Clarified the semantics of `max_score` on [problems](json_format#problems):
+  it represents the maximum score currently considered achievable, and for
+  problems with no known upper bound should be set to a reasonable initial
+  target and updated upward if exceeded during the contest.
 
 ## References
 


### PR DESCRIPTION
Closes #218 

Alternative to #262 

Explicitly says that `max_score` must be updated when needed (i.e. when a score higher than the current `max_score` is achieved). Now, `max_score` is always required for scoring.
