### PR TITLE
Add removed intervals to contest state

### DIFF
--- a/Contest_Control_System_Requirements.md
+++ b/Contest_Control_System_Requirements.md
@@ -342,6 +342,7 @@ It must be possible to, potentially retroactively, specify time intervals that
 will be disregarded for the purpose of scoring. The time during all such
 intervals will not be counted towards a team's penalty time for solved
 problems. Beginning and end of time intervals are given in wall-clock time.
+Time intervals must not overlap.
 
 Note that removing a time interval changes the wall-clock time when the contest
 ends, as the duration of the contest in

--- a/JSON_Format.md
+++ b/JSON_Format.md
@@ -886,6 +886,19 @@ Properties of a state object:
 | thawed           | TIME ? | Time when the scoreboard was thawed (that is, unfrozen again), or `null` if the scoreboard has not been thawed. Required iff `scoreboard_freeze_duration` is present in the [contest](#contest) endpoint. Must not be set if frozen is `null`.
 | finalized        | TIME ? | Time when the results were finalized, or `null` if results have not been finalized. Must not be set if ended is `null`.
 | end\_of\_updates | TIME ? | Time after last update to the contest occurred, or `null` if more updates are still to come. Setting this to non-`null` must be the very last change in the contest.
+| removed\_intervals   | array of removed interval objects ? | Time intervals that are disregarded for the purpose of scoring. See below.
+
+Properties of removed interval objects:
+
+| Name           | Type     | Description
+| :------------- | :------- | :----------
+| start          | TIME     | Wall-clock time when the interval starts.
+| end            | TIME ?   | Wall-clock time when the interval ends, or `null` if the interval is still ongoing.
+| contest\_time  | RELTIME  | Contest time at the start of the interval.
+
+The `removed_intervals` array must be sorted by `start` and intervals must not overlap.
+
+Events happening during a removed interval all receive the same contest time (equal to the `contest_time` of that interval). The contest time of all events after an interval is shifted back by the total duration of all removed intervals preceding them.
 
 These state changes must occur in the order listed in the table above,
 as far as they do occur, except that `thawed` and `finalized` may occur
@@ -911,7 +924,11 @@ and `thawed` is set if the contest was frozen.
   "frozen": "2014-06-25T14:00:00+01",
   "thawed": null,
   "finalized": null,
-  "end_of_updates": null
+  "end_of_updates": null,
+  "removed_intervals": [
+    {"start":"2014-06-25T11:30:00+01","end":"2014-06-25T11:45:00+01","contest_time":"1:30:00"},
+    {"start":"2014-06-25T13:00:00+01","end":null,"contest_time":"2:45:00"}
+  ]
 }
 ```
 

--- a/JSON_Format.md
+++ b/JSON_Format.md
@@ -878,14 +878,14 @@ scoreboard is frozen or results are final.
 
 Properties of a state object:
 
-| Name             | Type   | Description
-| :--------------- | :----- | :----------
-| started          | TIME ? | Time when the contest actually started, or `null` if the contest has not started yet. When set, this time must be equal to the [contest](#contest) `start_time`.
-| frozen           | TIME ? | Time when the scoreboard was frozen, or `null` if the scoreboard has not been frozen. Required iff `scoreboard_freeze_duration` is present in the [contest](#contest) endpoint.
-| ended            | TIME ? | Time when the contest ended, or `null` if the contest has not ended. Must not be set if started is `null`.
-| thawed           | TIME ? | Time when the scoreboard was thawed (that is, unfrozen again), or `null` if the scoreboard has not been thawed. Required iff `scoreboard_freeze_duration` is present in the [contest](#contest) endpoint. Must not be set if frozen is `null`.
-| finalized        | TIME ? | Time when the results were finalized, or `null` if results have not been finalized. Must not be set if ended is `null`.
-| end\_of\_updates | TIME ? | Time after last update to the contest occurred, or `null` if more updates are still to come. Setting this to non-`null` must be the very last change in the contest.
+| Name                 | Type   | Description
+| :------------------- | :----- | :----------
+| started              | TIME ? | Time when the contest actually started, or `null` if the contest has not started yet. When set, this time must be equal to the [contest](#contest) `start_time`.
+| frozen               | TIME ? | Time when the scoreboard was frozen, or `null` if the scoreboard has not been frozen. Required iff `scoreboard_freeze_duration` is present in the [contest](#contest) endpoint.
+| ended                | TIME ? | Time when the contest ended, or `null` if the contest has not ended. Must not be set if started is `null`.
+| thawed               | TIME ? | Time when the scoreboard was thawed (that is, unfrozen again), or `null` if the scoreboard has not been thawed. Required iff `scoreboard_freeze_duration` is present in the [contest](#contest) endpoint. Must not be set if frozen is `null`.
+| finalized            | TIME ? | Time when the results were finalized, or `null` if results have not been finalized. Must not be set if ended is `null`.
+| end\_of\_updates     | TIME ? | Time after last update to the contest occurred, or `null` if more updates are still to come. Setting this to non-`null` must be the very last change in the contest.
 | removed\_intervals   | array of removed interval objects ? | Time intervals that are disregarded for the purpose of scoring. See below.
 
 Properties of removed interval objects:

--- a/JSON_Format.md
+++ b/JSON_Format.md
@@ -994,26 +994,24 @@ Properties of a judgement object:
 | score                           | number    | Score for this judgement, between `0` and the problem's `max_score`. Required iff contest:scoreboard\_type is `score`.
 | current                         | boolean ? | `true` if this is the current judgement. Defaults to `true`. At any time, there must be at most one judgement per submission for which this is `true` or unset (and thus defaulting to `true`).
 | start\_time                     | TIME      | Absolute time when judgement started.
-| start\_contest\_time            | RELTIME   | Contest relative time when judgement started.
 | end\_time                       | TIME ?    | Absolute time when judgement completed. Required iff judgement\_type\_id is present.
-| end\_contest\_time              | RELTIME ? | Contest relative time when judgement completed. Required iff judgement\_type\_id is present.
 | max\_run\_time                  | number ?  | Maximum run time in seconds for any test case. Should be a non-negative integer multiple of `0.001`. The reason for this is to not have rounding ambiguities while still using the natural unit of seconds.
 
 A judgement must have at least one of `judgement_type_id` or `simplified_judgement_type_id` specified iff it is completed.
 If both `judgement_type_id` and `simplified_judgement_type_id` are present, they should be consistent with
 the simplification rules specified in the `judgement-types` endpoint. 
 
-When a judgement is started, each of `judgement_type_id`, `end_time` and
-`end_contest_time` will be `null` (or missing). These are set when the
+When a judgement is started, each of `judgement_type_id` and `end_time`
+will be `null` (or missing). These are set when the
 judgement is completed.
 
 #### Examples
 
 ```json
 [{"id":"189549","submission_id":"wf2017-32163123xz3132yy","judgement_type_id":"CE","start_time":"2014-06-25T11:22:48.427+01",
-  "start_contest_time":"1:22:48.427","end_time":"2014-06-25T11:23:32.481+01","end_contest_time":"1:23:32.481"},
+  "end_time":"2014-06-25T11:23:32.481+01"},
  {"id":"189550","submission_id":"wf2017-32163123xz3133ub","judgement_type_id":null,"start_time":"2014-06-25T11:24:03.921+01",
-  "start_contest_time":"1:24:03.921","end_time":null,"end_contest_time":null}
+  "end_time":null}
 ]
 ```
 
@@ -1031,7 +1029,6 @@ Properties of a run object:
 | ordinal             | integer | Ordering of runs in the judgement. Must be different for every run in a judgement. Runs for the same test case must have the same ordinal. Must be between 1 and `problem:test_data_count`.
 | judgement\_type\_id | ID      | The [verdict](#judgement-type) of this run (i.e. a judgement type).
 | time                | TIME    | Absolute time when run completed.
-| contest\_time       | RELTIME | Contest relative time when run completed.
 | run\_time           | number  | Run time in seconds. Should be a non-negative integer multiple of `0.001`. The reason for this is to not have rounding ambiguities while still using the natural unit of seconds.
 | score               | number ?| Score for this run. Only applicable when contest:scoreboard\_type is `score`. The meaning of this score is problem dependent; do not assume the final submission score is the minimum, maximum, or sum of the run scores. Note that a per-run score is not well-defined for most runs of most problems. Servers should omit `score` when it is not meaningful for the given problem.
 
@@ -1039,9 +1036,9 @@ Properties of a run object:
 
 ```json
 [{"id":"1312","judgement_id":"189549","ordinal":28,"judgement_type_id":"TLE",
-  "time":"2014-06-25T11:22:42.420+01","contest_time":"1:22:42.420","run_time":0.123},
+  "time":"2014-06-25T11:22:42.420+01","run_time":0.123},
  {"id":"1313","judgement_id":"189550","ordinal":1,"judgement_type_id":"AC",
-  "time":"2014-06-25T11:23:10.000+01","contest_time":"1:23:10.000","run_time":0.456,"score":42.5}
+  "time":"2014-06-25T11:23:10.000+01","run_time":0.456,"score":42.5}
 ]
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,13 @@ This is the draft of some future version of the CCS specification.
 - Added `coach` as a supported [account](json_format#accounts) type.
 - Added `desktop` and `webcam` as known [file reference](json_format#file-reference)
   tags.
+- Added `removed_intervals` to the [contest state](json_format#contest-state)
+  object, allowing time intervals to be marked as disregarded for scoring
+  purposes. Intervals must be non-overlapping and sorted by start time.
+- Removed `contest_time` from [judgements](json_format#judgements) and
+  [runs](json_format#runs), as these values are not meaningful for scoring
+  and would require unnecessary resending of objects when removed intervals
+  change.
 
 ## References
 


### PR DESCRIPTION
Alternate solution to #253 and #182.

- Adds `removed_intervals` to contest state
- Add requirement that removed intervals must be non-overlapping
- Removes `contest_time` from judgement and run
