### PR TITLE
Specify that `score.time` may be null when `score.score=0`

### DIFF
--- a/JSON_Format.md
+++ b/JSON_Format.md
@@ -1234,7 +1234,7 @@ Properties of a scoreboard row object:
 | score.num\_solved | integer   | Number of problems solved by the team. Required iff contest:scoreboard\_type is `pass-fail`.
 | score.total\_time | RELTIME   | Total penalty time accrued by the team. Required iff contest:scoreboard\_type is `pass-fail`.
 | score.score       | number    | Total score of problems by the team. Required iff contest:scoreboard\_type is `score`.
-| score.time        | RELTIME ? | Time of last score improvement, used for tiebreaking purposes. Must be `null` iff `num_solved=0`.
+| score.time        | RELTIME ? | Time of last score improvement, used for tiebreaking purposes. Must be `null` iff `num_solved=0` or `score=0`.
 | problems          | array of problem data objects ? | JSON array of problems with scoring data, see below for the specification of each object.
 
 Properties of a problem data object:


### PR DESCRIPTION
As the text currently reads, `time` may not be null when `num_solved` is null, which means that `time` may not be null for contests with `scoreboard_type='score'` (as `num_solved` must be null for scoring contests).

This PR specifies that `time` must also be null when `score=0`