### PR TITLE
Fix inconsistencies between `json-schema` and spec

### DIFF
--- a/json-schema/common.json
+++ b/json-schema/common.json
@@ -229,9 +229,9 @@
 		"type": "object",
 		"properties": {
 			"command": { "type": "string" },
-			"args": { "type": "string" },
-			"version": { "type": "string" },
-			"version_command": { "type": "string" }
+			"args": { "type": [ "string", "null" ] },
+			"version": { "type": [ "string", "null" ] },
+			"version_command": { "type": [ "string", "null" ] }
 		},
 		"required": ["command"],
 		"$comment": "ANCHOR_TO_INSERT_REQUIRE_STRICT_PROPERTIES"

--- a/json-schema/problem.json
+++ b/json-schema/problem.json
@@ -20,10 +20,10 @@
 		"name": { "type": "string" },
 		"ordinal": { "type": "integer" },
 		"rgb": {
-			"type": "string",
+			"type": [ "string", "null" ],
 			"pattern": "^#[A-Fa-f0-9]{3}([A-Fa-f0-9]{3})?$"
 		},
-		"color": { "type": "string" },
+		"color": { "type": [ "string", "null" ] },
 		"time_limit": {
 			"type": "number",
 			"multipleOf": 0.001,

--- a/json-schema/state.json
+++ b/json-schema/state.json
@@ -13,6 +13,5 @@
 		"finalized":      { "$ref": "common.json#/abstimeornull" },
 		"end_of_updates": { "$ref": "common.json#/abstimeornull" }
 	},
-	"required": ["started", "ended", "finalized", "end_of_updates"],
 	"$comment": "ANCHOR_TO_INSERT_REQUIRE_STRICT_PROPERTIES"
 }


### PR DESCRIPTION
This PR applies the following fixes to the json-schema:

- Make the `args`, `version`, and `version_command` properties of the command-object nullable, according to the [spec](ccs-specs.icpc.io/2026-01/contest_api#languages).
- Make the `rgb` and `color` properties of the problem endpoint nullable, according to the [spec](https://ccs-specs.icpc.io/2026-01/contest_api#problems).
- Make the `started`, `ended`, `finalized`, and `end_of_updates` properties of the contest-state endpoint non-required, according to the [spec](https://ccs-specs.icpc.io/2026-01/contest_api#contest-state). (In fact, these are often _required_ to be null).