### PR TITLE
Update `json-schema`: add `tag` list to `fileref` object

### DIFF
--- a/json-schema/common.json
+++ b/json-schema/common.json
@@ -148,7 +148,11 @@
 			"hash":     { "type": "string" },
 			"mime":     { "type": "string" },
 			"width":    { "type": "integer", "minimum": 1 },
-			"height":   { "type": "integer", "minimum": 1 }
+			"height":   { "type": "integer", "minimum": 1 },
+			"tag":      {
+				"type": "array",
+				"items": { "type": "string" }
+			}
 		},
 		"required": ["filename", "mime"],
 		"$comment": "ANCHOR_TO_INSERT_REQUIRE_STRICT_PROPERTIES"


### PR DESCRIPTION
The `FILE` object has a `tag` property in the spec, but none in the `json-schema`: https://ccs-specs.icpc.io/2026-01/contest_api#json-property-types