### PR TITLE
Add requirement for CLI submission utility

### DIFF
--- a/World_Finals_CCS_Requirements.md
+++ b/World_Finals_CCS_Requirements.md
@@ -277,6 +277,12 @@ endpoints MUST be compared with the ones exposed by the
 [Shadow CCS](ccs#shadow-mode) and SHOULD also be manually sanity checked before
 finalizing.
 
+## Team Interface
+
+### Submissions
+
+The CCS must provide both a command line interface (CLI) submission utility as well as a graphical user interface (or web-based interface) to each team to make a submission to the judging system.  The CLI submission utility must provide the same [Submission Contents](ccs#submission-contents) as specified in the base specification.
+
 ## Judging
 
 ### Judge Responses

--- a/World_Finals_CCS_Requirements.md
+++ b/World_Finals_CCS_Requirements.md
@@ -281,7 +281,8 @@ finalizing.
 
 ### Submissions
 
-The CCS must provide both a command line interface (CLI) submission utility as well as a graphical user interface (or web-based interface) to each team to make a submission to the judging system.  The CLI submission utility must provide the same [Submission Contents](ccs#submission-contents) as specified in the base specification.
+The CCS must provide both a command line interface (CLI) submission utility as well as a graphical user interface (or web-based interface) to each team to make a submission to the judging system.
+The CLI submission utility must support providing the same [Submission Contents](ccs#submission-contents) as specified in the base specification.
 
 ## Judging
 


### PR DESCRIPTION
Add CLI submission utility requirement indicating the CLI utility must meet the same requirements as in the base CCS document.

Closes #288 

