### PR TITLE
Add example completed execution judgment

### DIFF
--- a/JSON_Format.md
+++ b/JSON_Format.md
@@ -1012,10 +1012,11 @@ judgement is completed.
 #### Examples
 
 ```json
-[{"id":"189549","submission_id":"wf2017-32163123xz3132yy","judgement_type_id":"CE","start_time":"2014-06-25T11:22:48.427+01",
-  "end_time":"2014-06-25T11:23:32.481+01"},
- {"id":"189550","submission_id":"wf2017-32163123xz3133ub","judgement_type_id":null,"start_time":"2014-06-25T11:24:03.921+01",
-  "end_time":null}
+[{"id":"Run-3006499834222341010","submission_id":"s7","judgement_type_id":"CE","start_time":"2026-06-13T12:55:28.112-04",
+  "end_time":"2026-06-13T12:55:29.782-04","simplified_judgement_type_id":"CE"},
+ {"id":"Run-8806968035566460297","submission_id":"s8","start_time":"2026-06-13T12:56:38.033-04"},
+ {"id":"Run-8806968035566460297","submission_id":"s8","judgement_type_id":"TLE","start_time":"2026-06-13T12:56:38.033-04",
+  "end_time":"2026-06-13T12:56:59.715-04","max_run_time":2.006,"simplified_judgement_type_id":"RE"}
 ]
 ```
 

--- a/JSON_Format.md
+++ b/JSON_Format.md
@@ -1005,7 +1005,7 @@ A judgement must have at least one of `judgement_type_id` or `simplified_judgeme
 If both `judgement_type_id` and `simplified_judgement_type_id` are present, they should be consistent with
 the simplification rules specified in the `judgement-types` endpoint. 
 
-When a judgement is started, each of `judgement_type_id` and `end_time`
+When a judgement is started, each of `judgement_type_id`, `end_time` and `max_run_time`
 will be `null` (or missing). These are set when the
 judgement is completed.
 


### PR DESCRIPTION
1. Refreshed examples for judgements - it didn't seem plausible to have dates on example objects with the year 2014 when this version of the spec wasn't even thought of yet.  I was also wondering why the submission ID's started with "wf2017" (implying the 2017 world finals), but the dates said 2014.  We might as well _try_ to be consistent.  Probably, other examples in the doc should be refreshed as well... someday.
2. Removed the "**null**" `judgement_type_id` property from the 2nd example to illustrate that it is not required.
3. Added completed execution judgment example (TLE).
4. Added `simplified_judgement_type_id`'s where appropriate (might as well, since this version of the spec does tout that.)
5. Added that `max_run_time` will be null/missing when a judgment is started.

Fixes #293 