### PR TITLE
Add Clarification Categories

### DIFF
--- a/Contest_API.md
+++ b/Contest_API.md
@@ -180,7 +180,7 @@ suitable for the client making the request, as per the following example:
 
 ```json
 {"code":403,
- "message":"Teams cannot send clarifications to another team"}
+ "message":"Teams cannot send s to another team"}
  ```
 
 ### Authentication
@@ -283,7 +283,7 @@ The endpoints can be categorized into 4 types as follows:
 
 - Metadata: [api](#api-information), [access](#access)
 - Configuration: accounts, contests, judgement-types, languages, problems,
-  groups, organizations, persons, teams, categories;
+  groups, organizations, persons, teams, clarification-categories;
 - Live data: state, submissions, judgements, runs, clarifications, awards,
   commentary;
 - Aggregate data: [scoreboard](#scoreboard), [event-feed](#event-feed).
@@ -362,31 +362,31 @@ return a single JSON object. Properties returned are as specified by
 [access](#access). Some endpoints additionally support write methods; these are
 documented in dedicated sections below.
 
-| Endpoint                                 | JSON object                                                            | Notes
-| :--------------------------------------- | :--------------------------------------------------------------------- | :-----
-| `.`                                      | [API information](json_format#api-information)                         |
-| `contests/<id>/access`                   | [Access](#access)                                                      | API only; not in [Contest Package](contest_package)
-| `contests[/<id>]`                        | [Contest](json_format#contest)                                         | [Modifying contests](#modifying-contests) — PATCH
-| `contests/<id>/judgement-types[/<id>]`   | [Judgement Type](json_format#judgement-type)                           |
-| `contests/<id>/languages[/<id>]`         | [Language](json_format#language)                                       |
-| `contests/<id>/problems[/<id>]`          | [Problem](json_format#problem)                                         |
-| `contests/<id>/groups[/<id>]`            | [Group](json_format#group)                                             |
-| `contests/<id>/organizations[/<id>]`     | [Organization](json_format#organization)                               |
-| `contests/<id>/teams[/<id>]`             | [Team](json_format#team)                                               |
-| `contests/<id>/persons[/<id>]`           | [Person](json_format#person)                                           |
-| `contests/<id>/accounts[/<id>]`          | [Account](json_format#account)                                         |
-| `contests/<id>/account`                  | [Account](json_format#account)                                         | API only; not in [Contest Package](contest_package)
-| `contests/<id>/state`                    | [Contest state](json_format#contest-state)                             |
-| `contests/<id>/submissions[/<id>]`       | [Submission](json_format#submission)                                   | [Modifying submissions](#modifying-submissions) — POST/PUT
-| `contests/<id>/judgements[/<id>]`        | [Judgement](json_format#judgement)                                     |
-| `contests/<id>/runs[/<id>]`              | [Run](json_format#run)                                                 |
-| `contests/<id>/categories[/<id>]`        | [Clarification Category](json_format#clarification-category)           |
-| `contests/<id>/clarifications[/<id>]`    | [Clarification](json_format#clarification)                             | [Modifying clarifications](#modifying-clarifications) — POST/PUT
-| `contests/<id>/awards[/<id>]`            | [Award](json_format#award)                                             | [Modifying awards](#modifying-awards) — POST/PUT/PATCH/DELETE
-| `contests/<id>/commentary[/<id>]`        | [Commentary](json_format#commentary)                                   | [Modifying commentary](#modifying-commentary) — POST
-| `contests/<id>/scoreboard`               | [Scoreboard](json_format#scoreboard)                                   | See [Scoreboard](#scoreboard)
-| `contests/<id>/event-feed`               | [Notification object](json_format#notification)                        | See [Notifications](#notifications), [Event feed](#event-feed)
-| `webhooks[/<id>]`                        |                                                                        | See [Notifications](#notifications), [Webhooks](#webhooks)
+| Endpoint                                        | JSON object                                                            | Notes
+| :---------------------------------------------- | :--------------------------------------------------------------------- | :-----
+| `.`                                             | [API information](json_format#api-information)                         |
+| `contests/<id>/access`                          | [Access](#access)                                                      | API only; not in [Contest Package](contest_package)
+| `contests[/<id>]`                               | [Contest](json_format#contest)                                         | [Modifying contests](#modifying-contests) — PATCH
+| `contests/<id>/judgement-types[/<id>]`          | [Judgement Type](json_format#judgement-type)                           |
+| `contests/<id>/languages[/<id>]`                | [Language](json_format#language)                                       |
+| `contests/<id>/problems[/<id>]`                 | [Problem](json_format#problem)                                         |
+| `contests/<id>/groups[/<id>]`                   | [Group](json_format#group)                                             |
+| `contests/<id>/organizations[/<id>]`            | [Organization](json_format#organization)                               |
+| `contests/<id>/teams[/<id>]`                    | [Team](json_format#team)                                               |
+| `contests/<id>/persons[/<id>]`                  | [Person](json_format#person)                                           |
+| `contests/<id>/accounts[/<id>]`                 | [Account](json_format#account)                                         |
+| `contests/<id>/account`                         | [Account](json_format#account)                                         | API only; not in [Contest Package](contest_package)
+| `contests/<id>/state`                           | [Contest state](json_format#contest-state)                             |
+| `contests/<id>/submissions[/<id>]`              | [Submission](json_format#submission)                                   | [Modifying submissions](#modifying-submissions) — POST/PUT
+| `contests/<id>/judgements[/<id>]`               | [Judgement](json_format#judgement)                                     |
+| `contests/<id>/runs[/<id>]`                     | [Run](json_format#run)                                                 |
+| `contests/<id>/clarification-categories[/<id>]` | [Clarification Category](json_format#clarification-category)           |
+| `contests/<id>/clarifications[/<id>]`           | [Clarification](json_format#clarification)                             | [Modifying clarifications](#modifying-clarifications) — POST/PUT
+| `contests/<id>/awards[/<id>]`                   | [Award](json_format#award)                                             | [Modifying awards](#modifying-awards) — POST/PUT/PATCH/DELETE
+| `contests/<id>/commentary[/<id>]`               | [Commentary](json_format#commentary)                                   | [Modifying commentary](#modifying-commentary) — POST
+| `contests/<id>/scoreboard`                      | [Scoreboard](json_format#scoreboard)                                   | See [Scoreboard](#scoreboard)
+| `contests/<id>/event-feed`                      | [Notification object](json_format#notification)                        | See [Notifications](#notifications), [Event feed](#event-feed)
+| `webhooks[/<id>]`                               |                                                                        | See [Notifications](#notifications), [Webhooks](#webhooks)
 
 ### Access
 
@@ -914,25 +914,25 @@ Each notification is a [notification object](json_format#notification)
 as defined in JSON Format. The correspondence between notification types
 and API endpoints is:
 
-| Type            | API Endpoint                                     | JSON object
-| :-------------- | :----------------------------------------------- | :----------
-| contest         | `contests/<id>`                                  | [Contest](json_format#contest)
-| judgement-types | `contests/<id>/judgement-types/<id>`             | [Judgement Type](json_format#judgement-type)
-| languages       | `contests/<id>/languages/<id>`                   | [Language](json_format#language)
-| problems        | `contests/<id>/problems/<id>`                    | [Problem](json_format#problem)
-| groups          | `contests/<id>/groups/<id>`                      | [Group](json_format#group)
-| organizations   | `contests/<id>/organizations/<id>`               | [Organization](json_format#organization)
-| teams           | `contests/<id>/teams/<id>`                       | [Team](json_format#team)
-| persons         | `contests/<id>/persons/<id>`                     | [Person](json_format#person)
-| accounts        | `contests/<id>/accounts/<id>`                    | [Account](json_format#account)
-| state           | `contests/<id>/state`                            | [Contest state](json_format#contest-state)
-| submissions     | `contests/<id>/submissions/<id>`                 | [Submission](json_format#submission)
-| judgements      | `contests/<id>/judgements/<id>`                  | [Judgement](json_format#judgement)
-| runs            | `contests/<id>/runs/<id>`                        | [Run](json_format#run)
-| categories      | `contests/<id>/categories/<id>`                  | [Clarification Category](json_format#clarification-category)
-| clarifications  | `contests/<id>/clarifications/<id>`              | [Clarification](json_format#clarification)
-| awards          | `contests/<id>/awards/<id>`                      | [Award](json_format#award)
-| commentary      | `contests/<id>/commentary/<id>`                  | [Commentary](json_format#commentary)
+| Type                     | API Endpoint                                     | JSON object
+| :----------------------- | :----------------------------------------------- | :----------
+| contest                  | `contests/<id>`                                  | [Contest](json_format#contest)
+| judgement-types          | `contests/<id>/judgement-types/<id>`             | [Judgement Type](json_format#judgement-type)
+| languages                | `contests/<id>/languages/<id>`                   | [Language](json_format#language)
+| problems                 | `contests/<id>/problems/<id>`                    | [Problem](json_format#problem)
+| groups                   | `contests/<id>/groups/<id>`                      | [Group](json_format#group)
+| organizations            | `contests/<id>/organizations/<id>`               | [Organization](json_format#organization)
+| teams                    | `contests/<id>/teams/<id>`                       | [Team](json_format#team)
+| persons                  | `contests/<id>/persons/<id>`                     | [Person](json_format#person)
+| accounts                 | `contests/<id>/accounts/<id>`                    | [Account](json_format#account)
+| state                    | `contests/<id>/state`                            | [Contest state](json_format#contest-state)
+| submissions              | `contests/<id>/submissions/<id>`                 | [Submission](json_format#submission)
+| judgements               | `contests/<id>/judgements/<id>`                  | [Judgement](json_format#judgement)
+| runs                     | `contests/<id>/runs/<id>`                        | [Run](json_format#run)
+| clarification-categories | `contests/<id>/clarification-categories/<id>`    | [Clarification Category](json_format#clarification-category)
+| clarifications           | `contests/<id>/clarifications/<id>`              | [Clarification](json_format#clarification)
+| awards                   | `contests/<id>/awards/<id>`                      | [Award](json_format#award)
+| commentary               | `contests/<id>/commentary/<id>`                  | [Commentary](json_format#commentary)
 
 
 ### Event feed

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -283,7 +283,7 @@ The endpoints can be categorized into 4 types as follows:
 
 - Metadata: [api](#api-information), [access](#access)
 - Configuration: accounts, contests, judgement-types, languages, problems,
-  groups, organizations, persons, teams;
+  groups, organizations, persons, teams, categories;
 - Live data: state, submissions, judgements, runs, clarifications, awards,
   commentary;
 - Aggregate data: [scoreboard](#scoreboard), [event-feed](#event-feed).
@@ -366,25 +366,26 @@ documented in dedicated sections below.
 | :--------------------------------------- | :--------------------------------------------------------------------- | :-----
 | `.`                                      | [API information](json_format#api-information)                         |
 | `contests/<id>/access`                   | [Access](#access)                                                      | API only; not in [Contest Package](contest_package)
-| `contests[/<id>]`                        | [Contest](json_format#contest)                                        | [Modifying contests](#modifying-contests) — PATCH
-| `contests/<id>/judgement-types[/<id>]`   | [Judgement Type](json_format#judgement-type)                          |
-| `contests/<id>/languages[/<id>]`         | [Language](json_format#language)                                      |
-| `contests/<id>/problems[/<id>]`          | [Problem](json_format#problem)                                        |
-| `contests/<id>/groups[/<id>]`            | [Group](json_format#group)                                            |
-| `contests/<id>/organizations[/<id>]`     | [Organization](json_format#organization)                              |
-| `contests/<id>/teams[/<id>]`             | [Team](json_format#team)                                              |
-| `contests/<id>/persons[/<id>]`           | [Person](json_format#person)                                          |
-| `contests/<id>/accounts[/<id>]`          | [Account](json_format#account)                                        |
-| `contests/<id>/account`                  | [Account](json_format#account)                                        | API only; not in [Contest Package](contest_package)
+| `contests[/<id>]`                        | [Contest](json_format#contest)                                         | [Modifying contests](#modifying-contests) — PATCH
+| `contests/<id>/judgement-types[/<id>]`   | [Judgement Type](json_format#judgement-type)                           |
+| `contests/<id>/languages[/<id>]`         | [Language](json_format#language)                                       |
+| `contests/<id>/problems[/<id>]`          | [Problem](json_format#problem)                                         |
+| `contests/<id>/groups[/<id>]`            | [Group](json_format#group)                                             |
+| `contests/<id>/organizations[/<id>]`     | [Organization](json_format#organization)                               |
+| `contests/<id>/teams[/<id>]`             | [Team](json_format#team)                                               |
+| `contests/<id>/persons[/<id>]`           | [Person](json_format#person)                                           |
+| `contests/<id>/accounts[/<id>]`          | [Account](json_format#account)                                         |
+| `contests/<id>/account`                  | [Account](json_format#account)                                         | API only; not in [Contest Package](contest_package)
 | `contests/<id>/state`                    | [Contest state](json_format#contest-state)                             |
-| `contests/<id>/submissions[/<id>]`       | [Submission](json_format#submission)                                  | [Modifying submissions](#modifying-submissions) — POST/PUT
-| `contests/<id>/judgements[/<id>]`        | [Judgement](json_format#judgement)                                    |
-| `contests/<id>/runs[/<id>]`              | [Run](json_format#run)                                                |
-| `contests/<id>/clarifications[/<id>]`    | [Clarification](json_format#clarification)                            | [Modifying clarifications](#modifying-clarifications) — POST/PUT
-| `contests/<id>/awards[/<id>]`            | [Award](json_format#award)                                            | [Modifying awards](#modifying-awards) — POST/PUT/PATCH/DELETE
+| `contests/<id>/submissions[/<id>]`       | [Submission](json_format#submission)                                   | [Modifying submissions](#modifying-submissions) — POST/PUT
+| `contests/<id>/judgements[/<id>]`        | [Judgement](json_format#judgement)                                     |
+| `contests/<id>/runs[/<id>]`              | [Run](json_format#run)                                                 |
+| `contests/<id>/categories[/<id>]`        | [Clarification Category](json_format#clarification-category)           |
+| `contests/<id>/clarifications[/<id>]`    | [Clarification](json_format#clarification)                             | [Modifying clarifications](#modifying-clarifications) — POST/PUT
+| `contests/<id>/awards[/<id>]`            | [Award](json_format#award)                                             | [Modifying awards](#modifying-awards) — POST/PUT/PATCH/DELETE
 | `contests/<id>/commentary[/<id>]`        | [Commentary](json_format#commentary)                                   | [Modifying commentary](#modifying-commentary) — POST
 | `contests/<id>/scoreboard`               | [Scoreboard](json_format#scoreboard)                                   | See [Scoreboard](#scoreboard)
-| `contests/<id>/event-feed`               | [Notification object](json_format#notification)                 | See [Notifications](#notifications), [Event feed](#event-feed)
+| `contests/<id>/event-feed`               | [Notification object](json_format#notification)                        | See [Notifications](#notifications), [Event feed](#event-feed)
 | `webhooks[/<id>]`                        |                                                                        | See [Notifications](#notifications), [Webhooks](#webhooks)
 
 ### Access
@@ -928,6 +929,7 @@ and API endpoints is:
 | submissions     | `contests/<id>/submissions/<id>`                 | [Submission](json_format#submission)
 | judgements      | `contests/<id>/judgements/<id>`                  | [Judgement](json_format#judgement)
 | runs            | `contests/<id>/runs/<id>`                        | [Run](json_format#run)
+| categories      | `contests/<id>/categories/<id>`                  | [Clarification Category](json_format#clarification-category)
 | clarifications  | `contests/<id>/clarifications/<id>`              | [Clarification](json_format#clarification)
 | awards          | `contests/<id>/awards/<id>`                      | [Award](json_format#award)
 | commentary      | `contests/<id>/commentary/<id>`                  | [Commentary](json_format#commentary)

--- a/Contest_API.md
+++ b/Contest_API.md
@@ -180,7 +180,7 @@ suitable for the client making the request, as per the following example:
 
 ```json
 {"code":403,
- "message":"Teams cannot send s to another team"}
+ "message":"Teams cannot send clarifications to another team"}
  ```
 
 ### Authentication

--- a/JSON_Format.md
+++ b/JSON_Format.md
@@ -169,7 +169,7 @@ The general format for notification objects is:
 The known notification types are:
 `contest`, `judgement-types`, `languages`, `problems`, `groups`,
 `organizations`, `teams`, `persons`, `accounts`, `state`, `submissions`,
-`judgements`, `runs`, `categories`, `clarifications`, `awards`, `commentary`.
+`judgements`, `runs`, `clarification-categories`, `clarifications`, `awards`, `commentary`.
 
 Each notification object signals that an object or a collection has changed
 (and hence the contents of the corresponding endpoint) to `data`.

--- a/JSON_Format.md
+++ b/JSON_Format.md
@@ -1077,6 +1077,8 @@ Properties of a run object:
 ```
 ### Clarification Category
 
+Type name: `clarification-categories`
+
 A descriptive category for a [clarification](#clarification) that is not related to a [problem](#problem).
 
 Properties of the clarification category object:

--- a/JSON_Format.md
+++ b/JSON_Format.md
@@ -169,7 +169,7 @@ The general format for notification objects is:
 The known notification types are:
 `contest`, `judgement-types`, `languages`, `problems`, `groups`,
 `organizations`, `teams`, `persons`, `accounts`, `state`, `submissions`,
-`judgements`, `runs`, `clarifications`, `awards`, `commentary`.
+`judgements`, `runs`, `categories`, `clarifications`, `awards`, `commentary`.
 
 Each notification object signals that an object or a collection has changed
 (and hence the contents of the corresponding endpoint) to `data`.
@@ -1075,6 +1075,27 @@ Properties of a run object:
   "time":"2014-06-25T11:23:10.000+01","run_time":0.456,"score":42.5}
 ]
 ```
+### Clarification Category
+
+A descriptive category for a [clarification](#clarification) that is not related to a [problem](#problem).
+
+Properties of the clarification category object:
+
+| Name         | Type          | Description
+| :----------- | :------------ | :----------
+| id           | ID            | Identifier of the clarification category.
+| description  | string        | Description of the clarification category, e.g. "Systems"
+
+Clarification categories provide a mechanism for [clarifications](#clarification) to be directed to and answered by the appropriate group of people.
+
+#### Examples
+
+```json
+[{"id":"ops","description":"Operations"},
+ {"id":"systems","description":"Systems"},
+ {"id":"fnb","description":"Food & Beverage"}
+]
+```
 
 ### Clarification
 
@@ -1094,6 +1115,7 @@ Properties of a clarification message object:
 | to\_group\_ids | array of ID ?    | Identifiers of the [group(s)](#group) receiving this reply, `null` iff a reply to all teams or a request sent by a team.
 | reply\_to\_id  | ID ?             | Identifier of clarification this is in response to, otherwise `null`.
 | problem\_id    | ID ?             | Identifier of associated [problem](#problem), `null` iff not associated to a problem.
+| category\_id   | ID ?             | Identifier of the associated [clarification category][#clarification-category], `null` iff associated to a problem
 | text           | string           | Question or reply text.
 | time           | TIME             | Time of the question/reply.
 | contest\_time  | RELTIME          | Contest time of the question/reply.
@@ -1103,25 +1125,27 @@ The recipients of a clarification are the union of `to_team_ids` and `to_group_i
 Clarifications between a team and the judges are typically private. If the judges replies to a clarification and chooses to include additional recipients,
 then in order to preserve referential integrity the `reply_to_id` should be removed for everyone who couldn't see the original message.
 
+At least one of `problem_id` or `category_id` must be `null` or missing.  If both are `null` or missing, then the clarification is assumed to be a general clarification.
+
 #### Examples
 
 ```json
-[{"id":"wf2017-1","from_team_id":null,"to_team_ids":null,"to_group_ids":null,"reply_to_id":null,"problem_id":null,
-  "text":"Do not touch anything before the contest starts!","time":"2014-06-25T11:59:27.543+01","contest_time":"-0:15:32.457"}
+[{"id":"clar-1","from_team_id":null,"to_team_ids":null,"to_group_ids":null,"reply_to_id":null,
+  "text":"Do not touch anything before the contest starts!","time":"2026-06-16T11:12:45.167-04","contest_time":"-0:15:32.457"}
 ]
 ```
 
 ```json
-[{"id":"1","from_team_id":"34","to_team_ids":null,"to_group_ids":null,"reply_to_id":null,"problem_id":null,
-  "text":"May I ask a question?","time":"2017-06-25T11:59:27.543+01","contest_time":"1:59:27.543"},
+[{"id":"1","from_team_id":"34","to_team_ids":null,"to_group_ids":null,"reply_to_id":null,"problem_id":null,"category_id":"judges",
+  "text":"May I ask a question?","time":"2026-06-16T11:14:10.100-04","contest_time":"1:59:27.543"},
  {"id":"2","from_team_id":null,"to_team_ids":["34"],"reply_to_id":"1","problem_id":null,
-  "text":"Yes you may!","time":"2017-06-25T11:59:47.543+01","contest_time":"1:59:47.543"}
+  "text":"Yes you may!","time":"2026-06-16T11:14:30.100-04","contest_time":"1:59:47.543"}
 ]
 ```
 
 ```json
-[{"id":"1","from_team_id":"34","text":"May I ask a question?","time":"2017-06-25T11:59:27.543+01","contest_time":"1:59:27.543"},
- {"id":"2","to_team_ids":["34","57","69"],"to_group_ids":["1336"], "reply_to_id":"1","text":"Yes you may!","time":"2017-06-25T11:59:47.543+01","contest_time":"1:59:47.543"}
+[{"id":"1","from_team_id":"34","text":"May I ask a question?","time":"2026-06-16T11:20:00.067-04","contest_time":"1:59:27.543"},
+ {"id":"2","to_team_ids":["34","57","69"],"to_group_ids":["1336"], "reply_to_id":"1","text":"Yes you may!","time":"2026-06-16T11:20:30.267-04","contest_time":"1:59:47.543"}
 ]
 ```
 

--- a/JSON_Format.md
+++ b/JSON_Format.md
@@ -1093,6 +1093,7 @@ Clarification categories provide a mechanism for [clarifications](#clarification
 ```json
 [{"id":"ops","description":"Operations"},
  {"id":"systems","description":"Systems"},
+ {"id":"judges", "description":"Judging"},
  {"id":"fnb","description":"Food & Beverage"}
 ]
 ```


### PR DESCRIPTION
1. Updates to JSON format and API to include new object for clarification categories.
2. Update clarification object to include a category_id.
3. Update notifications to include "categories".
4. Updated examples for clarifications to included more consistent dates and to include an example using category_id.

I believe I tracked down the places that needed to be updated as a result of adding this new type.  If I missed anything, LMK.  Schema will probably have to be updated at some point, but I think @eldering usually does that?
