### PR TITLE
Remove Format reference to Scoreboard endpoint

### DIFF
--- a/JSON_Format.md
+++ b/JSON_Format.md
@@ -1205,10 +1205,7 @@ tags below are used.
 
 ### Scoreboard
 
-Scoreboard of the contest.
-
-Since this is generated data, only the `GET` method is allowed in the
-[Contest API](contest_api#scoreboard), irrespective of role.
+Scoreboard of the contest, generated from the other contest objects.
 
 Properties of the scoreboard object:
 


### PR DESCRIPTION
The Scoreboard in the JSON Format shouldn't include Contest API endpoint details.

It looks like this was just a copy/paste miss since the same text also exists in the Contest API 🤷🏼‍♂️, but it felt like we should still mention it is generated data here.

Fixes #299.