### PR TITLE
Markdown style updates for new mkdocs HTML generator

### DIFF
--- a/Contest_API.md
+++ b/Contest_API.md
@@ -181,7 +181,7 @@ suitable for the client making the request, as per the following example:
 ```json
 {"code":403,
  "message":"Teams cannot send clarifications to another team"}
- ```
+```
 
 ### Authentication
 
@@ -329,6 +329,7 @@ are supported by a given provider.
 
 In practice there are different types of providers that will offer
 similar sets of endpoints. Some examples:
+
  - A contest management system will support at least contests and
    teams, and may support other configuration endpoints.
  - A CCS will support at least submissions, judgements, and
@@ -960,10 +961,12 @@ the same order or set of events. The only guarantees are:
 - the latest notification sent for any object is the correct and current
 state of that object. E.g. if an object was created and deleted the
 delete notification will be sent last.
+
 - when a notification is sent the change it describes must already have
 happened. I.e. if a client receives an update for a certain endpoint a
 `GET` from that endpoint will return that state or possible some later
 state, but never an earlier state.
+
 - the notification for the [state endpoint](json_format#contest-state) setting
 `end_of_updates` must be the last event in the feed.
 

--- a/Contest_Package.md
+++ b/Contest_Package.md
@@ -148,6 +148,7 @@ Used for configuring a CCS (primary or shadow) before a contest. Suitable for
 download from a registration system or similar tool.
 
 Required files:
+
 - [api](json_format#api-information) (`api.json`)
 - [contests](json_format#contest) (`contest.json`)
 - [languages](json_format#language) (`languages.json`)
@@ -156,6 +157,7 @@ Required files:
 - [accounts](json_format#account) (`accounts.json`)
 
 Optional files:
+
 - [judgement-types](json_format#judgement-type) (`judgement-types.json`)
 - [groups](json_format#group) (`groups.json`)
 - [organizations](json_format#organization) (`organizations.json`)
@@ -202,6 +204,7 @@ Used for uploading local registration data to a central registration system
 (such as the ICPC CMS).
 
 Required files:
+
 - [api](json_format#api-information) (`api.json`)
 - [organizations](json_format#organization) (`organizations.json`)
 - [teams](json_format#team) (`teams.json`)
@@ -239,11 +242,13 @@ Used for uploading results from a finished contest to a central repository
 (such as the ICPC CMS).
 
 Required files:
+
 - [api](json_format#api-information) (`api.json`)
 - [teams](json_format#team) (`teams.json`)
 - [scoreboard](json_format#scoreboard) (`scoreboard.json`)
 
 Optional files:
+
 - [awards](json_format#award) (`awards.json`)
 
 #### Example file listing

--- a/STYLE.md
+++ b/STYLE.md
@@ -60,6 +60,7 @@ Use angle brackets for placeholders in endpoint paths and file patterns.
 Placeholder names should be lowercase and use hyphens, matching the style of the surrounding prose.
 
 **Examples:**
+
 - `/contests/<id>/<endpoint>`
 - `<endpoint>/<id>/<filename>`
 - `other-systems/<system>`
@@ -71,6 +72,7 @@ Wrap the entire path in backticks, including any placeholder tokens.
 When referencing another document in this repository, use a relative Markdown link whose href matches the target document's `permalink`.
 
 **Examples:**
+
 - `[JSON Format](json_format)`
 - `[Contest API](contest_api)`
 - `[file reference](json_format#file)`
@@ -128,6 +130,7 @@ Capitalize headers like normal sentences (sentence case),
 that is, only capitalize the first word and proper nouns.
 
 **Examples:**
+
 - ✅ "Example YAML files"
 - ✅ "CCS configuration"
 - ❌ "Example Yaml Files"


### PR DESCRIPTION
This introduces no contents changes. It just makes a few changes in markdown formatting since the old Jekyll HTML generator used the commonmark dialect, while mkdocs uses something slightly different.

Once this is approved and merged, I will apply similar changes to the release branches.