### PR TITLE
Make FileReference tags consistent in 2026-01

### DIFF
--- a/Contest_API.md
+++ b/Contest_API.md
@@ -273,7 +273,7 @@ Properties for file reference objects:
 | mime     | string          | Mime type of resource.
 | width    | integer ?       | Width of the image. Required for files with mime type image/\*.
 | height   | integer ?       | Height of the image. Required for files with mime type image/\*.
-| tag      | array of string | Intended usage hints (e.g. `light`, `dark` for images). No meaning must be implied or inferred from the order of the elements.
+| tags     | array of string | Intended usage hints (e.g. `light`, `dark` for images). No meaning must be implied or inferred from the order of the elements.
 
 The `href` property may be an [absolute or relative
 URL](https://datatracker.ietf.org/doc/html/rfc3986); relative URLs must be

--- a/Contest_Package.md
+++ b/Contest_Package.md
@@ -91,7 +91,7 @@ For images, the supported file extensions are:
 For images, a tag of `.<W>x<H>`, is interpreted as the file reference object
 having the `width` property set to  `<W>` and the `height` property set to
 `<H>`. Every other tag is interpreted as the file reference object having
-the value in its `tag` property array.
+the value in its `tags` property array.
 
 #### Hrefs
 

--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ Other versions of the CCS specifications are available
 These are the main changes made since the `2023-06` version:
 
    1. Add support for **post\_comment** capability (posting commentary)
-   2. Add property **tags** (array of string) to file reference objects (FILE) along with a description of how it may be used. (eg. hints such as light or dark for images)
+   2. Add property **tags** (array of string) to file reference objects (FILE) along with a description of how it may be used. (eg. hints such as light or dark for images) **This property was initially mis-published as 'tag'**
    3. contests endpoint
       1. Change **penalty\_time** from integer minutes to **RELTIME** (breaking change)
    4. judgement-types endpoint

--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ Other versions of the CCS specifications are available
 These are the main changes made since the `2023-06` version:
 
    1. Add support for **post\_comment** capability (posting commentary)
-   2. Add property **tag** (array of string) to file reference objects (FILE) along with a description of how it may be used. (eg. hints such as light or dark for images)
+   2. Add property **tags** (array of string) to file reference objects (FILE) along with a description of how it may be used. (eg. hints such as light or dark for images)
    3. contests endpoint
       1. Change **penalty\_time** from integer minutes to **RELTIME** (breaking change)
    4. judgement-types endpoint


### PR DESCRIPTION
We added a FileReference `tag` property in 2026-01, but this isn't consistent with how we've used plural elsewhere in the specification. Inconsistent enough that the only known implementations of it so far (CDS/ICPC tools/team view) had `tags` as a typo, and was successfully tested at NAC. See #305 for more details.

Normally we should fix the implementation and not touch a closed spec, but this seems like a minor typo that's still easy to correct and less change than the sole implementation.

No direct comments on the issue so I figured I'd open a PR for feedback. :)

First half of #305, second PR would change master.